### PR TITLE
fix(subagent): correct sessionDir, add stopReason completion, harden tmux

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 .env
 .pi/
 artifacts/
+# Local Pi runtime state
+.atl/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,62 @@ All notable changes to `@heyhuynhgiabuu/pi-task` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `.editorconfig` (root) — enforces `indent_style = space`,
+  `indent_size = 2`, `end_of_line = lf`, `charset = utf-8` so future
+  edits and automated tools stay aligned with the existing 2-space
+  convention.
+- `.gitignore` now excludes `.atl/` (Gentle AI / Pi runtime state).
+- `getSessionTerminalState` now returns the raw `stopReason` alongside
+  the terminal state, so callers can distinguish `error` from `length`
+  without re-walking the jsonl.
+
+### Changed
+
+- `TaskDetails.phase` value `"aborted"` renamed to `"cancelled"` to
+  match `TaskCompletionStatus`. Consumers that read
+  `details.phase === "aborted"` should treat both as user-cancellation.
+- Subagent completion detection now consults the most recent assistant
+  `stopReason` in the session jsonl. A subagent whose pi turn ends
+  cleanly (`stopReason: "stop"`) but whose tmux pane is still open is
+  now reported as `completed` instead of being polled to the 30-minute
+  timeout. `error` / `length` map to `failed`.
+- `killAgentPane` now guards with `paneExists` before issuing
+  `kill-pane` (prevents killing a recycled pane id) and accepts
+  `paneId: string | undefined` for the SDK (no-pane) path.
+- `splitWindowPane` now passes the command to `tmux split-window`
+  directly instead of using `send-keys`, eliminating a race where the
+  shell prompt could be unready and drop characters.
+- `readRegistry` returns `[]` for non-array JSON, hardening against a
+  partially-written or hand-edited `task-registry.json`.
+
+### Removed
+
+- `tmuxSteerPane` export (subagent follow-up / steer path is no
+  longer supported).
+- `buildTmuxSendKeysArgs` and `OUTPUT_FORMAT_GUIDE` from
+  `src/helpers.ts` (replaced by the direct `split-window` path and a
+  single canonical `TASK_RESULT_XML_INSTRUCTIONS` constant).
+- Duplicate tmux helpers (`tmuxCmd`, `hasTmux`, `paneExists`,
+  `getCurrentPaneId`, `splitWindowPane`, `killAgentPane`) that lived
+  in `src/index.ts`. `src/subagent/tmux.ts` is now the single source
+  of truth.
+
+### Fixed
+
+- `waitCompletion` was reading `<taskDir>/sessions/<name>` (a
+  non-existent nested path), so the session-text fallback never fired
+  and a subagent could only complete via `RESULT.md`. Callers now
+  pass `<taskDir>/sessions` directly; the path is centralised in
+  `resolveSessionDir(taskDir)`.
+- The `pane-alive` branch of `checkTaskCompletion` is now
+  dependency-injectable (`TaskCompletionOptions.paneExists`) so the
+  regression test is deterministic on every CI, not just machines
+  with a `tmux` binary on `PATH`.
+
 ## [0.1.2] — 2025
 
 ### Fixed
@@ -72,5 +128,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 See the git history: `git log --oneline -- CHANGELOG.md`.
 
 [0.1.1]: https://github.com/buddingnewinsights/pi-task/releases/tag/v0.1.1
-[Keep a Changelog]: https://keepachangelog.com/
-[Semantic Versioning]: https://semver.org/

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,6 @@ import { parseToolList } from "./agent-tools.js";
 import { parseMergedDisallowedTools } from "./policy.js";
 import { buildPiArgv } from "./subagent/buildArgv.js";
 
-
 export function parseMarkdownFrontmatter(content: string): {
   frontmatter: Record<string, string>;
   body: string;
@@ -86,8 +85,6 @@ export const TASK_RESULT_XML_INSTRUCTIONS = `<status>success|failure|blocked|par
 <files>Comma-separated absolute paths of files read/created (optional)</files>
 
 Prefer writing this block to RESULT.md when done. If you cannot write the file, your final assistant message MUST include the same XML block.`;
-
-export const OUTPUT_FORMAT_GUIDE = TASK_RESULT_XML_INSTRUCTIONS;
 
 export const TASK_TOOL_DESCRIPTION = `Launch a new agent to handle complex, multistep tasks autonomously.
 
@@ -186,13 +183,6 @@ export function parseIdTimestamp(id: string): number {
 
 export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-export function buildTmuxSendKeysArgs(
-  paneId: string,
-  command: string,
-): string[] {
-  return ["send-keys", "-t", paneId, command, "Enter"];
 }
 
 export interface BackgroundReceiptInput {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
-import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,7 +32,6 @@ import {
   TASK_BACKGROUND_DEFAULT,
   TASK_RESULT_XML_INSTRUCTIONS,
   TASK_TOOL_DESCRIPTION,
-  buildTmuxSendKeysArgs,
   formatBackgroundReceipt,
   buildPiArgs,
   parseResultXml,
@@ -46,7 +44,14 @@ import {
 } from "./helpers.js";
 import { runSdkSubagent } from "./subagent/runSdk.js";
 import {
+  hasTmux,
+  killAgentPane,
+  paneExists,
+  splitWindowPane,
+} from "./subagent/tmux.js";
+import {
   checkTaskCompletion,
+  resolveSessionDir,
   waitForTaskCompletion as waitForSessionTaskCompletion,
 } from "./subagent/waitCompletion.js";
 import { buildAgentToolSelection } from "./agent-tools.js";
@@ -95,7 +100,7 @@ interface TaskDetails {
   task_id: string;
   agent_type: string;
   description: string;
-  phase: "done" | "timeout" | "aborted" | "failed";
+  phase: "done" | "timeout" | "cancelled" | "failed";
   // Completed phase
   status?: string;
   summary?: string;
@@ -115,7 +120,8 @@ interface TaskDetails {
 function readRegistry(piDir: string): RegistryEntry[] {
   const path = join(piDir, "task-registry.json");
   try {
-    return JSON.parse(readFileSync(path, "utf-8"));
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
   }
@@ -124,82 +130,6 @@ function readRegistry(piDir: string): RegistryEntry[] {
 function writeRegistry(piDir: string, entries: RegistryEntry[]): void {
   const path = join(piDir, "task-registry.json");
   writeFileSync(path, JSON.stringify(entries, null, 2), "utf-8");
-}
-
-// ─── Tmux Helpers ────────────────────────────────────────────────────────────
-
-function tmuxCmd(args: string[]): string {
-  return execFileSync("tmux", args, {
-    encoding: "utf-8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
-}
-
-function hasTmux(): boolean {
-  try {
-    execFileSync("tmux", ["-V"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function paneExists(paneId: string): boolean {
-  try {
-    return tmuxCmd(["list-panes", "-a", "-F", "#{pane_id}"])
-      .split("\n")
-      .includes(paneId);
-  } catch {
-    return false;
-  }
-}
-
-function getCurrentPaneId(): string | null {
-  try {
-    return tmuxCmd(["display-message", "-p", "#{pane_id}"]);
-  } catch {
-    return null;
-  }
-}
-
-function splitWindowPane(
-  cwd: string,
-  command: string,
-): { paneId: string; originalPane: string | null } {
-  const originalPane = getCurrentPaneId();
-  const paneId = tmuxCmd([
-    "split-window",
-    "-h",
-    "-P",
-    "-F",
-    "#{pane_id}",
-    "-c",
-    cwd,
-  ]);
-  execFileSync("tmux", buildTmuxSendKeysArgs(paneId, command), {
-    stdio: "ignore",
-  });
-  return { paneId, originalPane };
-}
-
-function killAgentPane(
-  paneId: string | undefined,
-  originalPane: string | null,
-): void {
-  if (paneId) {
-    try {
-      if (paneExists(paneId)) tmuxCmd(["kill-pane", "-t", paneId]);
-    } catch {
-      /* ignore */
-    }
-  }
-  if (originalPane) {
-    try {
-      tmuxCmd(["select-pane", "-t", originalPane]);
-    } catch {
-      /* ignore */
-    }
-  }
 }
 
 // ─── Process a completed task (sendMessage + registry cleanup) ──────────────
@@ -364,9 +294,6 @@ export default function (pi: ExtensionAPI) {
   const TREE_LAST = "\u2514\u2500"; // └─
 
   function c(color: string, text: string): string {
-    // widgetTheme is a Theme object with a .fg(color, text) method,
-    // not a callable. Calling it as a function throws "widgetTheme is not
-    // a function" which the outer try/catch in renderWidget swallows.
     return widgetTheme ? widgetTheme.fg(color, text) : text;
   }
 
@@ -517,8 +444,7 @@ export default function (pi: ExtensionAPI) {
 
       const snapshot = await checkTaskCompletion({
         resultPath: join(task.dir, "RESULT.md"),
-        sessionDir: task.dir,
-        sessionName: task.sessionName,
+        sessionDir: resolveSessionDir(task.dir),
         paneId: task.paneId,
       });
 
@@ -789,7 +715,7 @@ export default function (pi: ExtensionAPI) {
         TASK_RESULT_XML_INSTRUCTIONS,
       ].join("\n");
 
-      const sessionDir = join(artifactDir, "sessions");
+      const sessionDir = resolveSessionDir(artifactDir);
       await mkdir(sessionDir, { recursive: true });
 
       // ─── Build and run the sub-agent pi process ──────────────────────────
@@ -977,10 +903,9 @@ export default function (pi: ExtensionAPI) {
         const completion = await waitForSessionTaskCompletion({
           resultPath,
           sessionDir,
-          sessionName,
           paneId,
           signal,
-          timeoutMs: 30 * 60 * 1000,
+          timeoutMs: TASK_TIMEOUT_MS,
         });
         const content = completion.content;
         const phase =
@@ -1132,7 +1057,7 @@ export default function (pi: ExtensionAPI) {
 
       if (
         d.phase === "timeout" ||
-        d.phase === "aborted" ||
+        d.phase === "cancelled" ||
         d.phase === "failed"
       ) {
         const line =

--- a/src/session-text.ts
+++ b/src/session-text.ts
@@ -48,3 +48,85 @@ export function getLastAssistantTextFromSessionDir(sessionDir: string): string {
   }
   return last;
 }
+
+/**
+ * Terminal state of the subagent's pi session, derived from the most recent
+ * assistant message's `stopReason`.
+ *
+ * - "stopped"  : the last assistant message exists and is not mid-tool-call.
+ *                This covers:
+ *                  - API responses with `stopReason: "stop"` (clean turn end)
+ *                  - Local synthesis messages (no stopReason, no api field)
+ *                    that pi appends after the final tool result of a turn.
+ *                The TUI may still be open, waiting for the next user input.
+ * - "running"  : the last assistant message has `stopReason: "toolUse"`. The
+ *                subagent is mid-turn and waiting for a tool result.
+ * - "errored"  : the last assistant message has `stopReason` "error" or
+ *                "length" (API failure / context overflow). Other unknown
+ *                values are treated as "stopped", not failures.
+ * - "unknown"  : no jsonl file, no assistant message yet, or an empty
+ *                stopReason.
+ */
+export type SessionTerminalState =
+  | "stopped"
+  | "running"
+  | "errored"
+  | "unknown";
+
+/**
+ * Richer return from `getSessionTerminalState`. The `state` mirrors the
+ * terminal-state enum; `stopReason` is the raw `stopReason` from the
+ * most recent assistant message (or `null` when no assistant message
+ * exists, the message has no `stopReason` field — e.g. local synthesis
+ * — or the state is "unknown"). Surfacing the actual stopReason lets
+ * callers distinguish "error" from "length" without a second jsonl walk.
+ */
+export interface SessionTerminalStateInfo {
+  state: SessionTerminalState;
+  stopReason: string | null;
+}
+
+export function getSessionTerminalState(
+  sessionDir: string,
+): SessionTerminalStateInfo {
+  if (!existsSync(sessionDir)) return { state: "unknown", stopReason: null };
+  const files = readdirSync(sessionDir)
+    .filter((f) => f.endsWith(".jsonl"))
+    .sort();
+  if (files.length === 0) return { state: "unknown", stopReason: null };
+
+  // Iterate files newest-first; within each file walk lines bottom-up so the
+  // first assistant message we hit is the most recent one in the directory.
+  for (let i = files.length - 1; i >= 0; i--) {
+    const file = files[i];
+    const content = readFileSync(join(sessionDir, file), "utf-8");
+    const lines = content.split("\n");
+    for (let j = lines.length - 1; j >= 0; j--) {
+      const line = lines[j].trim();
+      if (!line) continue;
+      // pi writes stopReason on the message object (message.stopReason),
+      // not at the JSONL entry top level.
+      let entry: {
+        type?: string;
+        message?: { role?: string; stopReason?: string };
+      };
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (entry.type !== "message") continue;
+      if (entry.message?.role !== "assistant") continue;
+      const stopReason = entry.message?.stopReason;
+      if (stopReason === "toolUse") return { state: "running", stopReason };
+      // "error" and "length" map to "errored" so the parent can surface
+      // the failure; everything else (including the common "stop" and
+      // local-synthesis cases) is treated as "stopped".
+      if (stopReason === "error" || stopReason === "length") {
+        return { state: "errored", stopReason };
+      }
+      return { state: "stopped", stopReason: stopReason ?? null };
+    }
+  }
+  return { state: "unknown", stopReason: null };
+}

--- a/src/subagent/tmux.ts
+++ b/src/subagent/tmux.ts
@@ -1,5 +1,5 @@
 /**
- * Tmux helpers for subagent panes (shared by task extension).
+ * Tmux helpers for subagent panes (shared by task extension + completion poll).
  */
 
 import { execFileSync } from "node:child_process";
@@ -7,13 +7,13 @@ import { execFileSync } from "node:child_process";
 export function tmuxCmd(args: string[]): string {
   return execFileSync("tmux", args, {
     encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "pipe"],
   }).trim();
 }
 
 export function hasTmux(): boolean {
   try {
-    execFileSync("tmux", ["-V"], { stdio: "pipe" });
+    execFileSync("tmux", ["-V"], { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -22,8 +22,9 @@ export function hasTmux(): boolean {
 
 export function paneExists(paneId: string): boolean {
   try {
-    const out = tmuxCmd(["list-panes", "-a", "-F", "#{pane_id}"]);
-    return out.split("\n").includes(paneId);
+    return tmuxCmd(["list-panes", "-a", "-F", "#{pane_id}"])
+      .split("\n")
+      .includes(paneId);
   } catch {
     return false;
   }
@@ -42,6 +43,10 @@ export function splitWindowPane(
   command: string,
 ): { paneId: string; originalPane: string | null } {
   const originalPane = getCurrentPaneId();
+  // Pass the command directly to split-window. tmux waits for the new shell
+  // to be ready before executing it, avoiding the send-keys race where the
+  // shell processes an incomplete line because Enter arrives before all
+  // characters have been typed.
   const paneId = tmuxCmd([
     "split-window",
     "-h",
@@ -55,14 +60,22 @@ export function splitWindowPane(
   return { paneId, originalPane };
 }
 
+/**
+ * Kill the subagent pane and restore focus to the original pane.
+ *
+ * Guards the kill with paneExists so a stale/recycled pane id cannot target
+ * the wrong pane, and tolerates an undefined paneId (e.g. SDK path).
+ */
 export function killAgentPane(
-  paneId: string,
+  paneId: string | undefined,
   originalPane: string | null,
 ): void {
-  try {
-    tmuxCmd(["kill-pane", "-t", paneId]);
-  } catch {
-    /* already dead */
+  if (paneId) {
+    try {
+      if (paneExists(paneId)) tmuxCmd(["kill-pane", "-t", paneId]);
+    } catch {
+      /* ignore */
+    }
   }
   if (originalPane) {
     try {
@@ -71,11 +84,4 @@ export function killAgentPane(
       /* ignore */
     }
   }
-}
-
-/** Inject keys into a running subagent pane (steer / follow-up). */
-export function tmuxSteerPane(paneId: string, message: string): void {
-  const escaped = message.replace(/'/g, `'\"'\"'`);
-  tmuxCmd(["send-keys", "-t", paneId, "-l", escaped]);
-  tmuxCmd(["send-keys", "-t", paneId, "Enter"]);
 }

--- a/src/subagent/waitCompletion.ts
+++ b/src/subagent/waitCompletion.ts
@@ -1,7 +1,10 @@
+import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { getLastAssistantTextFromSessionDir } from "../session-text.js";
+import {
+  getLastAssistantTextFromSessionDir,
+  getSessionTerminalState,
+} from "../session-text.js";
 import { paneExists } from "./tmux.js";
 
 export type TaskCompletionStatus =
@@ -20,8 +23,15 @@ export interface TaskCompletionSnapshot {
 export interface TaskCompletionOptions {
   resultPath: string;
   sessionDir: string;
-  sessionName: string;
   paneId?: string;
+  /**
+   * Predicate that reports whether a tmux pane is currently alive. The
+   * default uses the real `paneExists` (which shells out to `tmux`).
+   * Tests inject a synchronous mock so the pane-alive branch of the
+   * completion state machine can be exercised deterministically on
+   * machines that do not have a tmux server.
+   */
+  paneExists?: (paneId: string) => boolean;
   signal?: AbortSignal;
   timeoutMs?: number;
   pollMs?: number;
@@ -33,28 +43,73 @@ async function readResultFile(resultPath: string): Promise<string | null> {
   return text.length > 0 ? text : null;
 }
 
-function readSessionText(
-  sessionDir: string,
-  sessionName: string,
-): string | null {
-  const sessionPath = join(sessionDir, "sessions", sessionName);
-  const text = getLastAssistantTextFromSessionDir(sessionPath).trim();
+function readSessionText(sessionDir: string): string | null {
+  // sessionDir is already the sessions directory (artifactDir/sessions).
+  // pi writes jsonl files directly inside it as <session-id>.jsonl.
+  const text = getLastAssistantTextFromSessionDir(sessionDir).trim();
   return text.length > 0 ? text : null;
+}
+
+/**
+ * Resolve the sessions directory for a task artifact root.
+ *
+ * pi writes session jsonl files directly into `<artifactDir>/sessions`
+ * (one file per session id). Centralising the join here means a future
+ * change to the on-disk layout only has to touch one place, and the
+ * wiring in `src/index.ts` can be unit-tested.
+ */
+export function resolveSessionDir(taskDir: string): string {
+  return join(taskDir, "sessions");
 }
 
 export async function checkTaskCompletion(
   options: TaskCompletionOptions,
 ): Promise<TaskCompletionSnapshot> {
-  const result = await readResultFile(options.resultPath);
-  if (result) {
-    return { status: "completed", content: result, source: "result-file" };
+  // Dependency-injected so the pane-alive branch is testable without a
+  // real tmux server (see TaskCompletionOptions.paneExists).
+  const paneExistsFn = options.paneExists ?? paneExists;
+
+  // 1. RESULT.md is the primary completion signal.
+  const resultFile = await readResultFile(options.resultPath);
+  if (resultFile) {
+    return { status: "completed", content: resultFile, source: "result-file" };
   }
 
-  if (options.paneId && paneExists(options.paneId)) {
+  // 2. If the subagent's last assistant turn ended with stopReason "stop"
+  //    (or a non-tool-use error like "error"/"length"), the work is done even
+  //    if the TUI pane is still open waiting for the next user input.
+  const { state: terminalState, stopReason } = getSessionTerminalState(
+    options.sessionDir,
+  );
+  if (terminalState === "stopped" || terminalState === "errored") {
+    const sessionText = readSessionText(options.sessionDir);
+    if (sessionText) {
+      return {
+        status: terminalState === "errored" ? "failed" : "completed",
+        content: sessionText,
+        source: "session-jsonl",
+      };
+    }
+    // No assistant text to surface — fall back to a diagnostic that names
+    // the real stopReason (so "error" and "length" are not conflated).
+    const stopReasonLabel =
+      stopReason ?? (terminalState === "stopped" ? "stop" : "error");
+    return {
+      status: terminalState === "errored" ? "failed" : "completed",
+      content: `Subagent ended (stopReason: ${stopReasonLabel}) but did not write ${options.resultPath} and produced no final text. Inspect the session jsonl in ${options.sessionDir} for tool calls and intermediate output.`,
+      source: "session-jsonl",
+    };
+  }
+
+  // 3. Assistant is still mid-turn or session has not produced a jsonl yet.
+  //    If the pane is alive, the subagent is running.
+  if (options.paneId && paneExistsFn(options.paneId)) {
     return { status: "running", content: "", source: "pane" };
   }
 
-  const sessionText = readSessionText(options.sessionDir, options.sessionName);
+  // 4. Pane is dead but we still have session text from a previous turn.
+  //    (Legacy fallback; in practice step 2 catches the stopReason case.)
+  const sessionText = readSessionText(options.sessionDir);
   if (sessionText) {
     return {
       status: "completed",
@@ -63,6 +118,7 @@ export async function checkTaskCompletion(
     };
   }
 
+  // 5. Pane dead, nothing to show → failed.
   if (options.paneId) {
     return {
       status: "failed",
@@ -72,6 +128,7 @@ export async function checkTaskCompletion(
     };
   }
 
+  // 6. No paneId (e.g. SDK path), no completion signal yet → still running.
   return { status: "running", content: "", source: "pane" };
 }
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -14,7 +14,6 @@ import {
   formatMs,
   parseIdTimestamp,
   shellQuote,
-  buildTmuxSendKeysArgs,
   formatBackgroundReceipt,
   TASK_BACKGROUND_DEFAULT,
   TASK_RESULT_XML_INSTRUCTIONS,
@@ -28,6 +27,11 @@ import {
   formatAgentList,
   type AgentConfig,
 } from "../src/helpers.js";
+import {
+  getLastAssistantTextFromSessionDir,
+  getSessionTerminalState,
+} from "../src/session-text.js";
+import { checkTaskCompletion, resolveSessionDir } from "../src/subagent/waitCompletion.js";
 
 // ─── extractTag ──────────────────────────────────────────────────────────────
 
@@ -866,12 +870,26 @@ import {
 // ─── Task tool hardening contracts ───────────────────────────────────────────
 
 {
-  const t = "buildTmuxSendKeysArgs keeps task command as one raw tmux argument";
+  const t =
+    "shellQuote preserves embedded single quotes and backticks verbatim";
+  // The local splitWindowPane passes the whole shell line through split-window,
+  // so the parent must quote agent paths/args with embedded ' and ` such that
+  // the spawned shell sees the original characters as one literal argument.
   const command = "cd '/tmp/safe path' && echo $(must-not-run) && echo `nope`";
-  assert.deepEqual(
-    buildTmuxSendKeysArgs("session:1.2", command),
-    ["send-keys", "-t", "session:1.2", command, "Enter"],
-    t,
+  assert.equal(
+    shellQuote("/tmp/safe path"),
+    "'/tmp/safe path'",
+    `${t} (plain path)`,
+  );
+  assert.equal(
+    shellQuote("it's tricky"),
+    "'it'\"'\"'s tricky'",
+    `${t} (escaped quote)`,
+  );
+  assert.equal(
+    shellQuote(command),
+    "'cd '\"'\"'/tmp/safe path'\"'\"' && echo $(must-not-run) && echo `nope`'",
+    `${t} (full command)`,
   );
 }
 
@@ -915,6 +933,54 @@ import {
 }
 
 {
+  const t =
+    "getSessionTerminalState treats local synthesis (no stopReason) as stopped";
+  // pi appends a final assistant message locally after a tool result, with
+  // no stopReason and no api field. That is the common "subagent is done"
+  // shape and must be treated as "stopped" so the parent can return.
+  const root = mkdtempSync(join(tmpdir(), "pi-task-state-local-"));
+  try {
+    const dir = join(root, "sessions");
+    mkdirSync(dir, { recursive: true });
+    writeJsonl(dir, "s1.jsonl", [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done." }],
+        },
+        // no stopReason, no api
+      },
+    ]);
+    const local = getSessionTerminalState(dir);
+    assert.equal(local.state, "stopped", `${t}: local synthesis is stopped`);
+    assert.equal(
+      local.stopReason,
+      null,
+      `${t}: local synthesis has no stopReason`,
+    );
+
+    // stopReason=length maps to errored so the parent can surface the failure.
+    writeJsonl(dir, "s2.jsonl", [
+      assistantMessage("length", "context too long"),
+    ]);
+    const lengthInfo = getSessionTerminalState(dir);
+    assert.equal(
+      lengthInfo.state,
+      "errored",
+      `${t}: stopReason=length is errored`,
+    );
+    assert.equal(
+      lengthInfo.stopReason,
+      "length",
+      `${t}: stopReason=length surfaces the raw value`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
   const t = "XML instructions preserve the required task result tags";
   for (const tag of ["status", "summary", "findings", "evidence", "files"]) {
     assert.ok(
@@ -926,6 +992,278 @@ import {
       `${t}: has closing ${tag}`,
     );
   }
+}
+
+// ─── Session terminal state + completion detection contracts ───────────────
+
+function writeJsonl(dir: string, name: string, lines: object[]): void {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, name);
+  const body = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  writeFileSync(path, body, "utf-8");
+}
+
+function assistantMessage(stopReason: string, text: string): object {
+  return {
+    type: "message",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      stopReason,
+    },
+  };
+}
+
+{
+  const root = mkdtempSync(join(tmpdir(), "pi-task-state-"));
+  try {
+    const dir = join(root, "sessions");
+
+    // No directory yet.
+    let info = getSessionTerminalState(dir);
+    assert.equal(info.state, "unknown", "missing dir is unknown");
+    assert.equal(info.stopReason, null, "missing dir has no stopReason");
+
+    // Empty directory.
+    mkdirSync(dir, { recursive: true });
+    info = getSessionTerminalState(dir);
+    assert.equal(info.state, "unknown", "empty dir is unknown");
+    assert.equal(info.stopReason, null, "empty dir has no stopReason");
+
+    // No assistant message yet (only setup entries).
+    writeJsonl(dir, "2026-06-21T00-00-00.jsonl", [
+      { type: "session", id: "x" },
+      { type: "session_info", id: "y" },
+    ]);
+    info = getSessionTerminalState(dir);
+    assert.equal(info.state, "unknown", "only setup entries is unknown");
+    assert.equal(info.stopReason, null, "setup-only has no stopReason");
+
+    // Assistant mid-turn: toolUse.
+    writeJsonl(dir, "2026-06-21T00-00-01.jsonl", [
+      assistantMessage("toolUse", "thinking..."),
+    ]);
+    info = getSessionTerminalState(dir);
+    assert.equal(info.state, "running", "toolUse means still running");
+    assert.equal(
+      info.stopReason,
+      "toolUse",
+      "toolUse surfaces the raw stopReason",
+    );
+
+    // Assistant finished cleanly.
+    writeJsonl(dir, "2026-06-21T00-00-02.jsonl", [
+      assistantMessage("stop", "Done. <episode>...</episode>"),
+    ]);
+    info = getSessionTerminalState(dir);
+    assert.equal(info.state, "stopped", "stop means finished");
+    assert.equal(info.stopReason, "stop", "stop surfaces the raw stopReason");
+
+    // Assistant hit a non-tool error.
+    writeJsonl(dir, "2026-06-21T00-00-03.jsonl", [
+      assistantMessage("error", "boom"),
+    ]);
+    info = getSessionTerminalState(dir);
+    assert.equal(info.state, "errored", "error means errored");
+    assert.equal(
+      info.stopReason,
+      "error",
+      "error surfaces the raw stopReason",
+    );
+
+    // Trailing lines after the last assistant turn must not affect state.
+    writeJsonl(dir, "2026-06-21T00-00-04.jsonl", [
+      assistantMessage("stop", "final"),
+      { type: "noise", after: true },
+    ]);
+    info = getSessionTerminalState(dir);
+    assert.equal(
+      info.state,
+      "stopped",
+      "non-message lines after stop do not flip state",
+    );
+    assert.equal(
+      info.stopReason,
+      "stop",
+      "trailing noise does not change the surfaced stopReason",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t =
+    "checkTaskCompletion returns completed when session stopped even if pane is alive";
+  const root = mkdtempSync(join(tmpdir(), "pi-task-completion-"));
+  try {
+    const sessionDir = join(root, "sessions");
+    mkdirSync(sessionDir, { recursive: true });
+    writeJsonl(sessionDir, "s1.jsonl", [
+      assistantMessage("stop", "<episode>ok</episode>"),
+    ]);
+    const resultPath = join(root, "RESULT.md"); // intentionally missing
+    const snapshot = await checkTaskCompletion({
+      resultPath,
+      sessionDir,
+      paneId: "%99", // pretend a live pane
+    });
+    assert.equal(snapshot.status, "completed", `${t}: status`);
+    assert.equal(
+      snapshot.source,
+      "session-jsonl",
+      `${t}: source is session-jsonl`,
+    );
+    assert.ok(
+      snapshot.content.includes("<episode>ok</episode>"),
+      `${t}: content is the assistant text`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t =
+    "checkTaskCompletion returns failed when session errored without RESULT.md";
+  const root = mkdtempSync(join(tmpdir(), "pi-task-completion-err-"));
+  try {
+    const sessionDir = join(root, "sessions");
+    mkdirSync(sessionDir, { recursive: true });
+    writeJsonl(sessionDir, "s1.jsonl", [
+      assistantMessage("error", "rate limit hit"),
+    ]);
+    const snapshot = await checkTaskCompletion({
+      resultPath: join(root, "RESULT.md"),
+      sessionDir,
+      paneId: "%99",
+    });
+    assert.equal(snapshot.status, "failed", `${t}: status`);
+    assert.ok(
+      snapshot.content.includes("rate limit hit"),
+      `${t}: content is the assistant text`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t =
+    "checkTaskCompletion diagnostic names the real stopReason when session errored with no text";
+  const root = mkdtempSync(join(tmpdir(), "pi-task-completion-err-diagnostic-"));
+  try {
+    const sessionDir = join(root, "sessions");
+    mkdirSync(sessionDir, { recursive: true });
+    // stopReason "error" with no text content → readSessionText returns
+    // null → fallback diagnostic must name the real stopReason, not the
+    // terminal-state name.
+    writeJsonl(sessionDir, "s1.jsonl", [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+        },
+      },
+    ]);
+    const snapshot = await checkTaskCompletion({
+      resultPath: join(root, "RESULT.md"),
+      sessionDir,
+      paneId: "%99",
+    });
+    assert.equal(snapshot.status, "failed", `${t}: status`);
+    assert.equal(snapshot.source, "session-jsonl", `${t}: source`);
+    assert.ok(
+      snapshot.content.includes("stopReason: error"),
+      `${t}: diagnostic names the real stopReason`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t =
+    "checkTaskCompletion returns running while pane is alive and session is mid toolUse";
+  // Pane aliveness is dependency-injected so this branch is exercisable
+  // on every CI, not just machines with a tmux server on PATH.
+  const root = mkdtempSync(join(tmpdir(), "pi-task-completion-mid-"));
+  try {
+    const sessionDir = join(root, "sessions");
+    mkdirSync(sessionDir, { recursive: true });
+    writeJsonl(sessionDir, "s1.jsonl", [
+      assistantMessage("toolUse", "calling read..."),
+    ]);
+    const snapshot = await checkTaskCompletion({
+      resultPath: join(root, "RESULT.md"),
+      sessionDir,
+      paneId: "%99", // arbitrary: the injected paneExists ignores the id
+      paneExists: () => true,
+    });
+    assert.equal(snapshot.status, "running", `${t}: status`);
+    assert.equal(snapshot.source, "pane", `${t}: source`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t =
+    "checkTaskCompletion prefers RESULT.md over session jsonl when both exist";
+  const root = mkdtempSync(join(tmpdir(), "pi-task-completion-both-"));
+  try {
+    const sessionDir = join(root, "sessions");
+    mkdirSync(sessionDir, { recursive: true });
+    writeJsonl(sessionDir, "s1.jsonl", [
+      assistantMessage("stop", "from session"),
+    ]);
+    const resultPath = join(root, "RESULT.md");
+    writeFileSync(resultPath, "from RESULT.md\n", "utf-8");
+    const snapshot = await checkTaskCompletion({
+      resultPath,
+      sessionDir,
+      paneId: "%99",
+    });
+    assert.equal(snapshot.status, "completed", `${t}: status`);
+    assert.equal(snapshot.source, "result-file", `${t}: result-file wins`);
+    assert.equal(
+      snapshot.content,
+      "from RESULT.md",
+      `${t}: content is RESULT.md`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t =
+    "getLastAssistantTextFromSessionDir reads the same dir the helper fixes pointed at";
+  // Regression: the readSessionText path used to be <sessionDir>/sessions/<name>;
+  // ensure the helper itself still reads <sessionDir> directly.
+  const root = mkdtempSync(join(tmpdir(), "pi-task-read-"));
+  try {
+    const sessionDir = join(root, "sessions");
+    mkdirSync(sessionDir, { recursive: true });
+    writeJsonl(sessionDir, "abc.jsonl", [
+      assistantMessage("stop", "hello from session"),
+    ]);
+    const text = getLastAssistantTextFromSessionDir(sessionDir);
+    assert.equal(text, "hello from session", t);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t = "resolveSessionDir joins the sessions segment to the task dir";
+  assert.equal(
+    resolveSessionDir("/tmp/.pi/tasks/task-123"),
+    join("/tmp/.pi/tasks/task-123", "sessions"),
+    t,
+  );
 }
 
 console.log("ALL TASK HELPER TESTS PASSED");


### PR DESCRIPTION
## Summary

Fixes the subagent completion-detection pipeline and hardens the tmux
helper layer. The most impactful change is a new `getSessionTerminalState`
that reads the most recent assistant `stopReason` from the session jsonl,
so a subagent whose pi turn ends cleanly but whose tmux pane stays open
is now reported as `completed` instead of being polled to the 30-minute
timeout. Alongside: a real bug where the session-text fallback pointed
at a non-existent nested path (so it silently never worked), a
`kill-pane` guard against recycled pane ids, elimination of a
`send-keys` race in pane creation, and removal of the duplicate tmux
helpers in `index.ts`.

## Bug fixes

- **sessionDir path (`waitCompletion`):** the session-text fallback
  used to join a non-existent `<taskDir>/sessions/<name>` path and
  therefore never fired. Caller now passes `<taskDir>/sessions`
  directly via the new `resolveSessionDir(taskDir)` helper
  (unit-tested to prevent wiring regression).
- **Completion state machine (`getSessionTerminalState`):** a
  subagent whose pi turn ends with `stopReason: "stop"` (or
  `"error"`/`"length"`) but whose tmux pane is still open was
  reported as `running` until the 30-minute timeout. The new
  priority chain is `RESULT.md > stopReason > pane alive >
  session text > failed > running`. The helper now also returns
  the raw `stopReason` so the diagnostic message can name the
  real value (`error` vs `length`) instead of the state name.
- **`killAgentPane` guard:** `paneExists` is consulted before
  `kill-pane` to prevent killing a recycled pane id, and
  `paneId: string | undefined` is accepted for the SDK (no-pane)
  path.
- **`splitWindowPane` race:** the command is now passed to
  `tmux split-window` directly instead of `send-keys`, so tmux
  waits for the new shell to be ready before injecting it
  (eliminates dropped characters on slow prompts).
- **`readRegistry` hardening:** non-array JSON in
  `task-registry.json` (corrupt, partial write, hand edit) now
  returns `[]` instead of propagating a non-array to callers.
- **`TaskDetails.phase` rename:** `"aborted"` → `"cancelled"`
  to match `TaskCompletionStatus` (the old value silently
  bypassed the cancellation render path).

## Cleanup

- Duplicate tmux helpers (`tmuxCmd`, `hasTmux`, `paneExists`,
  `getCurrentPaneId`, `splitWindowPane`, `killAgentPane`) removed
  from `src/index.ts`; `src/subagent/tmux.ts` is now the single
  source of truth.
- Dead exports removed: `buildTmuxSendKeysArgs`,
  `OUTPUT_FORMAT_GUIDE`, `tmuxSteerPane` (the steer/follow-up
  path is no longer supported).
- `.editorconfig` (indent=space, size=2) added to prevent future
  indentation drift. `.gitignore` excludes `.atl/`.
- `CHANGELOG` `[Unreleased]` entry covering the public-API changes
  (rename + removed exports) for downstream consumers.

## Tests

- `getSessionTerminalState` now returns `{ state, stopReason }` and
  the test suite asserts both fields for every branch
  (`stop` / `toolUse` / `error` / `length` / local synthesis /
  unknown / trailing noise).
- The pane-alive branch of `checkTaskCompletion` is now
  dependency-injectable via `TaskCompletionOptions.paneExists`,
  so the regression test is deterministic on every CI (not just
  machines with a `tmux` binary on `PATH`). This was a gate
  blocker in the pre-PR review.
- New regression test: the errored-no-text fallback diagnostic
  must name the real `stopReason` (e.g. `stopReason: error`),
  not the terminal-state name.
- New unit test: `resolveSessionDir` joins the sessions segment
  to the task dir (guards the wiring fix against future reverts).
- All changes covered by `npx tsc --noEmit` (clean) and
  `npm test` (1/1 pass).

## Follow-ups (out of scope, tracked as issues)

- Session-text helpers (`getSessionTerminalState`,
  `getLastAssistantTextFromSessionDir`) need a top-level
  try/catch so an `EACCES` on the sessions dir cannot crash the
  background polling loop and silently drop the task.
- Add at least a `console.error` (with `paneId` / `sessionDir` /
  `taskId`) to every currently-silent catch block
  (`killAgentPane`, `select-pane`, jsonl parse, registry read) so
  SLO regressions are visible.
- Consider tail-reading or streaming the jsonl files instead of
  full-loading on every poll (matters for long-running subagents
  with multi-MB sessions).
- Tighten the test file to `describe`/`it` blocks (currently
  `tsx --test` reports the whole file as one case).
- Document the POSIX-shell assumption near `splitWindowPane`
  (the `default-shell` tmux option could weaken `shellQuote`).
- Scope `paneExists` to the relevant tmux session instead of
  the whole server.
