### PR TITLE
fix: pin HerdR tasks to the parent tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- HerdR subagents are pinned to the parent Pi tab instead of splitting whichever tab is globally focused.
+
 ## [0.3.0] - 2026-07-13
 
 ### Added

--- a/src/subagent/herdr.ts
+++ b/src/subagent/herdr.ts
@@ -11,6 +11,7 @@ import {
 interface HerdrPane {
   pane_id: string;
   terminal_id: string;
+  tab_id?: string;
 }
 
 interface HerdrResponse<T> {
@@ -63,6 +64,14 @@ function paneFrom(value: unknown): HerdrPane {
   return pane as HerdrPane;
 }
 
+function parentTabFrom(value: unknown): string {
+  const pane = paneFrom(value);
+  if (typeof pane.tab_id !== "string" || !pane.tab_id) {
+    throw new Error("HerdR parent pane response did not include tab_id");
+  }
+  return pane.tab_id;
+}
+
 function splitDirectionFromLayout(
   layout: HerdrLayout,
   paneId: string,
@@ -113,6 +122,11 @@ export function createHerdrTerminalBackend(
     return "right";
   };
 
+  const resolveParentTab = async (): Promise<string> => {
+    const response = await run(["pane", "get", env.HERDR_PANE_ID as string]);
+    return parentTabFrom(decode(response.stdout, "parent pane get"));
+  };
+
   const verifyOwnership = async (rawHandle: Parameters<TerminalBackend["isAlive"]>[0]): Promise<HerdrTerminalHandle> => {
     const handle = requireHerdrHandle(rawHandle);
     if (!socketPath || handle.socketPath !== socketPath) {
@@ -133,7 +147,7 @@ export function createHerdrTerminalBackend(
       if (env.HERDR_ENV !== "1" || !env.HERDR_PANE_ID || !socketPath || !isAbsolute(socketPath)) return false;
       try {
         await run(["status", "server"]);
-        await run(["pane", "current", "--current"]);
+        await resolveParentTab();
         return true;
       } catch {
         return false;
@@ -145,10 +159,12 @@ export function createHerdrTerminalBackend(
         if (env.HERDR_ENV !== "1" || !env.HERDR_PANE_ID || !socketPath || !isAbsolute(socketPath)) {
           throw new Error("HerdR backend requires Pi to run inside an active HerdR pane");
         }
+        const parentTab = await resolveParentTab();
         const direction = await chooseSplitDirection(input.direction);
         const response = await run([
           "agent", "start", input.label ?? "pi-task",
           "--cwd", input.cwd,
+          "--tab", parentTab,
           "--split", direction,
           "--no-focus",
           "--", "sh", "-lc", input.command,

--- a/test/herdrBackend.test.ts
+++ b/test/herdrBackend.test.ts
@@ -6,6 +6,7 @@ import { createHerdrTerminalBackend, createSyncHerdrControl } from "../src/subag
 test("HerdR launch returns a socket-scoped terminal handle", async () => {
   const calls: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
   const outputs = [
+    JSON.stringify({ pane: { pane_id: "w1:p1", terminal_id: "term-1", tab_id: "w1:t1" } }),
     JSON.stringify({ layout: { panes: [{ pane_id: "w1:p1", rect: { width: 160, height: 40 } }] } }),
     JSON.stringify({ agent: { pane_id: "w1:p2", terminal_id: "term-2" } }),
   ];
@@ -29,11 +30,14 @@ test("HerdR launch returns a socket-scoped terminal handle", async () => {
     socketPath: "/tmp/herdr.sock",
     terminalId: "term-2",
   });
-  assert.deepEqual(calls[0]?.args, ["pane", "layout", "--pane", "w1:p1"]);
-  assert.deepEqual(calls[1]?.args.slice(0, 3), ["agent", "start", "pi-task"]);
-  assert.deepEqual(calls[1]?.args.slice(-4), ["--", "sh", "-lc", "pi --session task"]);
-  assert.ok(calls[1]?.args.includes("right"));
-  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0]?.args, ["pane", "get", "w1:p1"]);
+  assert.deepEqual(calls[1]?.args, ["pane", "layout", "--pane", "w1:p1"]);
+  assert.deepEqual(calls[2]?.args.slice(0, 3), ["agent", "start", "pi-task"]);
+  assert.deepEqual(calls[2]?.args.slice(-4), ["--", "sh", "-lc", "pi --session task"]);
+  assert.ok(calls[2]?.args.includes("right"));
+  const tabFlag = calls[2]?.args.indexOf("--tab") ?? -1;
+  assert.equal(calls[2]?.args[tabFlag + 1], "w1:t1");
+  assert.equal(calls.length, 3);
 });
 
 test("parallel HerdR launches serialize layout inspection and agent creation", async () => {
@@ -41,6 +45,12 @@ test("parallel HerdR launches serialize layout inspection and agent creation", a
   let maxActiveStarts = 0;
   let nextId = 1;
   const run = async (_command: string, args: readonly string[]) => {
+    if (args[0] === "pane" && args[1] === "get") {
+      return {
+        stdout: JSON.stringify({ pane: { pane_id: "w1:p1", terminal_id: "term-1", tab_id: "w1:t1" } }),
+        stderr: "",
+      };
+    }
     if (args[0] === "pane") {
       return {
         stdout: JSON.stringify({ layout: { panes: [{ pane_id: "w1:p1", rect: { width: 160, height: 40 } }] } }),
@@ -77,6 +87,7 @@ test("parallel HerdR launches serialize layout inspection and agent creation", a
 test("HerdR chooses a downward split for a narrow caller pane", async () => {
   const calls: string[][] = [];
   const outputs = [
+    JSON.stringify({ pane: { pane_id: "w1:p1", terminal_id: "term-1", tab_id: "w1:t1" } }),
     JSON.stringify({ layout: { panes: [{ pane_id: "w1:p1", rect: { width: 88, height: 41 } }] } }),
     JSON.stringify({ agent: { pane_id: "w1:p2", terminal_id: "term-2" } }),
   ];
@@ -93,7 +104,31 @@ test("HerdR chooses a downward split for a narrow caller pane", async () => {
   });
 
   await backend.launch({ command: "pi", cwd: "/repo" });
-  assert.ok(calls[1]?.includes("down"));
+  assert.ok(calls[2]?.includes("down"));
+});
+
+test("HerdR launch fails closed when the parent tab cannot be resolved", async () => {
+  const calls: string[][] = [];
+  const backend = createHerdrTerminalBackend({
+    env: {
+      HERDR_ENV: "1",
+      HERDR_PANE_ID: "w1:p1",
+      HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+    },
+    run: async (_command, args) => {
+      calls.push([...args]);
+      return {
+        stdout: JSON.stringify({ pane: { pane_id: "w1:p1", terminal_id: "term-1" } }),
+        stderr: "",
+      };
+    },
+  });
+
+  await assert.rejects(
+    backend.launch({ command: "pi", cwd: "/repo" }),
+    /tab_id/,
+  );
+  assert.deepEqual(calls, [["pane", "get", "w1:p1"]]);
 });
 
 test("HerdR ownership is checked before reads", async () => {


### PR DESCRIPTION
## Summary

- resolve the parent tab from `HERDR_PANE_ID` before launching a HerdR subagent
- pass that exact tab to `herdr agent start --tab` instead of relying on global UI focus
- fail closed when the parent tab cannot be resolved
- validate the configured parent pane in backend availability checks

## Bug

`herdr agent start --split` without `--tab` uses the globally focused HerdR tab. If a user focuses another workspace between Pi startup and task delegation, `pi-task` can split the worker into that unrelated session. The task handle remains valid, but the worker appears to take over another active workspace.

## Verification

- `npm exec -- tsx --test test/herdrBackend.test.ts` — 8 passed
- `npm run typecheck` — passed
- `npm test` — 37 passed

The regression test asserts that the launch command includes the tab returned by `pane get $HERDR_PANE_ID`, and that launch aborts before `agent start` if no parent `tab_id` is available.