### PR TITLE
fix(herdr): retry stalled prompt submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- HerdR initial prompts now wait for an observed agent state transition and retry Enter once when submission stalls, preventing child panes from remaining idle with the task prompt in the editor.
+
 ## [0.3.8] - 2026-07-28
 
 ### Added

--- a/src/subagent/herdr.ts
+++ b/src/subagent/herdr.ts
@@ -116,8 +116,8 @@ function isAgentPaneBusy(error: unknown): boolean {
   return /agent_pane_busy|not an available shell/i.test(errorText(error));
 }
 
-function isAgentWaitTimeout(error: unknown): boolean {
-  return /timed out waiting for agent status|"code"\s*:\s*"timeout"/i.test(
+function isAgentPromptRetryable(error: unknown): boolean {
+  return /agent_prompt_stalled|timed out waiting for agent status|"code"\s*:\s*"timeout"|"code"\s*:\s*"agent_prompt_stalled"/i.test(
     errorText(error),
   );
 }
@@ -274,17 +274,12 @@ export function createHerdrTerminalBackend(
             }
           }
           if (input.initialPrompt !== undefined) {
-            await run([
-              "pane",
-              "send-text",
+            const promptArgs = [
+              "agent",
+              "prompt",
               created.pane_id,
               input.initialPrompt,
-            ]);
-            await sleep(300);
-            const submissionObserved = run([
-              "agent",
-              "wait",
-              created.pane_id,
+              "--wait",
               "--until",
               "working",
               "--until",
@@ -292,17 +287,26 @@ export function createHerdrTerminalBackend(
               "--until",
               "done",
               "--timeout",
-              "5000",
-            ]).then(
-              () => true,
-              (error) => {
-                if (isAgentWaitTimeout(error)) return false;
-                throw error;
-              },
-            );
-            await run(["pane", "send-keys", created.pane_id, "enter"]);
-            if (!(await submissionObserved)) {
-              await run(["pane", "send-keys", created.pane_id, "enter"]);
+              "8000",
+            ];
+            try {
+              await run(promptArgs);
+            } catch (error) {
+              if (!isAgentPromptRetryable(error)) throw error;
+              await run(["agent", "send-keys", created.pane_id, "enter"]);
+              await run([
+                "agent",
+                "wait",
+                created.pane_id,
+                "--until",
+                "working",
+                "--until",
+                "blocked",
+                "--until",
+                "done",
+                "--timeout",
+                "8000",
+              ]);
             }
           }
           if (groupKey) {

--- a/src/subagent/herdr.ts
+++ b/src/subagent/herdr.ts
@@ -116,6 +116,12 @@ function isAgentPaneBusy(error: unknown): boolean {
   return /agent_pane_busy|not an available shell/i.test(errorText(error));
 }
 
+function isAgentWaitTimeout(error: unknown): boolean {
+  return /timed out waiting for agent status|"code"\s*:\s*"timeout"/i.test(
+    errorText(error),
+  );
+}
+
 function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
@@ -269,11 +275,35 @@ export function createHerdrTerminalBackend(
           }
           if (input.initialPrompt !== undefined) {
             await run([
-              "agent",
-              "prompt",
+              "pane",
+              "send-text",
               created.pane_id,
               input.initialPrompt,
             ]);
+            await sleep(300);
+            const submissionObserved = run([
+              "agent",
+              "wait",
+              created.pane_id,
+              "--until",
+              "working",
+              "--until",
+              "blocked",
+              "--until",
+              "done",
+              "--timeout",
+              "5000",
+            ]).then(
+              () => true,
+              (error) => {
+                if (isAgentWaitTimeout(error)) return false;
+                throw error;
+              },
+            );
+            await run(["pane", "send-keys", created.pane_id, "enter"]);
+            if (!(await submissionObserved)) {
+              await run(["pane", "send-keys", created.pane_id, "enter"]);
+            }
           }
           if (groupKey) {
             const group = existingGroup ?? {

--- a/test/herdrBackend.test.ts
+++ b/test/herdrBackend.test.ts
@@ -219,7 +219,7 @@ test("ungrouped HerdR launch splits the caller pane before starting Pi", async (
   ]);
 });
 
-test("HerdR separates initial task text from the explicit Enter submission", async () => {
+test("HerdR submits initial task text through agent prompt wait", async () => {
   const calls: string[][] = [];
   const backend = createHerdrTerminalBackend({
     env: {
@@ -253,26 +253,28 @@ test("HerdR separates initial task text from the explicit Enter submission", asy
     initialPrompt,
   });
 
-  assert.deepEqual(calls.slice(-3), [
-    ["pane", "send-text", "w1:p2", initialPrompt],
-    [
-      "agent",
-      "wait",
-      "w1:p2",
-      "--until",
-      "working",
-      "--until",
-      "blocked",
-      "--until",
-      "done",
-      "--timeout",
-      "5000",
-    ],
-    ["pane", "send-keys", "w1:p2", "enter"],
+  assert.deepEqual(calls.at(-1), [
+    "agent",
+    "prompt",
+    "w1:p2",
+    initialPrompt,
+    "--wait",
+    "--until",
+    "working",
+    "--until",
+    "blocked",
+    "--until",
+    "done",
+    "--timeout",
+    "8000",
   ]);
+  assert.equal(
+    calls.some((args) => args[0] === "pane" && args[1] === "send-text"),
+    false,
+  );
 });
 
-test("HerdR retries Enter when initial submission causes no state change", async () => {
+test("HerdR retries stalled initial prompt through agent-level Enter", async () => {
   const calls: string[][] = [];
   const backend = createHerdrTerminalBackend({
     env: {
@@ -290,14 +292,14 @@ test("HerdR retries Enter when initial submission causes no state change", async
           stderr: "",
         };
       }
-      if (args[0] === "agent" && args[1] === "wait") {
+      if (args[0] === "agent" && args[1] === "prompt") {
         const error = new Error("herdr exited unsuccessfully") as Error & {
           stderr?: string;
         };
         error.stderr = JSON.stringify({
           error: {
-            code: "timeout",
-            message: "timed out waiting for agent status",
+            code: "agent_prompt_stalled",
+            message: "prompt did not observe a state change",
           },
         });
         throw error;
@@ -317,8 +319,23 @@ test("HerdR retries Enter when initial submission causes no state change", async
     initialPrompt: "Review the diff.",
   });
 
-  assert.deepEqual(calls.slice(-4), [
-    ["pane", "send-text", "w1:p2", "Review the diff."],
+  assert.deepEqual(calls.slice(-3), [
+    [
+      "agent",
+      "prompt",
+      "w1:p2",
+      "Review the diff.",
+      "--wait",
+      "--until",
+      "working",
+      "--until",
+      "blocked",
+      "--until",
+      "done",
+      "--timeout",
+      "8000",
+    ],
+    ["agent", "send-keys", "w1:p2", "enter"],
     [
       "agent",
       "wait",
@@ -330,11 +347,104 @@ test("HerdR retries Enter when initial submission causes no state change", async
       "--until",
       "done",
       "--timeout",
-      "5000",
+      "8000",
     ],
-    ["pane", "send-keys", "w1:p2", "enter"],
-    ["pane", "send-keys", "w1:p2", "enter"],
   ]);
+});
+
+test("HerdR rejects non-retryable initial prompt failures", async () => {
+  const backend = createHerdrTerminalBackend({
+    env: {
+      HERDR_ENV: "1",
+      HERDR_PANE_ID: "w1:p1",
+      HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+    },
+    run: async (_command, args) => {
+      if (args[0] === "pane" && args[1] === "split") {
+        return {
+          stdout: JSON.stringify({
+            pane: { pane_id: "w1:p2", terminal_id: "term-2" },
+          }),
+          stderr: "",
+        };
+      }
+      if (args[0] === "agent" && args[1] === "prompt") {
+        const error = new Error("agent identity mismatch");
+        throw error;
+      }
+      return {
+        stdout: JSON.stringify({
+          agent: { pane_id: "w1:p2", terminal_id: "term-2" },
+        }),
+        stderr: "",
+      };
+    },
+  });
+
+  await assert.rejects(
+    backend.launch({
+      cwd: "/repo",
+      agentArgs: ["--session", "task"],
+      initialPrompt: "Review the diff.",
+    }),
+    /agent identity mismatch/,
+  );
+});
+
+test("HerdR settles retry command failures without detached waiters", async () => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    const backend = createHerdrTerminalBackend({
+      env: {
+        HERDR_ENV: "1",
+        HERDR_PANE_ID: "w1:p1",
+        HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+      },
+      run: async (_command, args) => {
+        if (args[0] === "pane" && args[1] === "split") {
+          return {
+            stdout: JSON.stringify({
+              pane: { pane_id: "w1:p2", terminal_id: "term-2" },
+            }),
+            stderr: "",
+          };
+        }
+        if (args[0] === "agent" && args[1] === "prompt") {
+          const error = new Error("herdr exited unsuccessfully") as Error & {
+            stderr?: string;
+          };
+          error.stderr = JSON.stringify({
+            error: { code: "timeout", message: "timed out waiting" },
+          });
+          throw error;
+        }
+        if (args[0] === "agent" && args[1] === "send-keys") {
+          throw new Error("send failed");
+        }
+        return {
+          stdout: JSON.stringify({
+            agent: { pane_id: "w1:p2", terminal_id: "term-2" },
+          }),
+          stderr: "",
+        };
+      },
+    });
+
+    await assert.rejects(
+      backend.launch({
+        cwd: "/repo",
+        agentArgs: ["--session", "task"],
+        initialPrompt: "Review the diff.",
+      }),
+      /send failed/,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
 });
 
 test("parallel HerdR launches serialize workspace and pane creation", async () => {

--- a/test/herdrBackend.test.ts
+++ b/test/herdrBackend.test.ts
@@ -219,7 +219,7 @@ test("ungrouped HerdR launch splits the caller pane before starting Pi", async (
   ]);
 });
 
-test("HerdR sends the initial task prompt as raw agent input after startup", async () => {
+test("HerdR separates initial task text from the explicit Enter submission", async () => {
   const calls: string[][] = [];
   const backend = createHerdrTerminalBackend({
     env: {
@@ -253,11 +253,87 @@ test("HerdR sends the initial task prompt as raw agent input after startup", asy
     initialPrompt,
   });
 
-  assert.deepEqual(calls.at(-1), [
-    "agent",
-    "prompt",
-    "w1:p2",
-    initialPrompt,
+  assert.deepEqual(calls.slice(-3), [
+    ["pane", "send-text", "w1:p2", initialPrompt],
+    [
+      "agent",
+      "wait",
+      "w1:p2",
+      "--until",
+      "working",
+      "--until",
+      "blocked",
+      "--until",
+      "done",
+      "--timeout",
+      "5000",
+    ],
+    ["pane", "send-keys", "w1:p2", "enter"],
+  ]);
+});
+
+test("HerdR retries Enter when initial submission causes no state change", async () => {
+  const calls: string[][] = [];
+  const backend = createHerdrTerminalBackend({
+    env: {
+      HERDR_ENV: "1",
+      HERDR_PANE_ID: "w1:p1",
+      HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+    },
+    run: async (_command, args) => {
+      calls.push([...args]);
+      if (args[0] === "pane" && args[1] === "split") {
+        return {
+          stdout: JSON.stringify({
+            pane: { pane_id: "w1:p2", terminal_id: "term-2" },
+          }),
+          stderr: "",
+        };
+      }
+      if (args[0] === "agent" && args[1] === "wait") {
+        const error = new Error("herdr exited unsuccessfully") as Error & {
+          stderr?: string;
+        };
+        error.stderr = JSON.stringify({
+          error: {
+            code: "timeout",
+            message: "timed out waiting for agent status",
+          },
+        });
+        throw error;
+      }
+      return {
+        stdout: JSON.stringify({
+          agent: { pane_id: "w1:p2", terminal_id: "term-2" },
+        }),
+        stderr: "",
+      };
+    },
+  });
+
+  await backend.launch({
+    cwd: "/repo",
+    agentArgs: ["--session", "task"],
+    initialPrompt: "Review the diff.",
+  });
+
+  assert.deepEqual(calls.slice(-4), [
+    ["pane", "send-text", "w1:p2", "Review the diff."],
+    [
+      "agent",
+      "wait",
+      "w1:p2",
+      "--until",
+      "working",
+      "--until",
+      "blocked",
+      "--until",
+      "done",
+      "--timeout",
+      "5000",
+    ],
+    ["pane", "send-keys", "w1:p2", "enter"],
+    ["pane", "send-keys", "w1:p2", "enter"],
   ]);
 });
 


### PR DESCRIPTION
## Summary

- submit HerdR task text and Enter as separate pane operations
- watch child lifecycle before sending Enter
- retry Enter once when no `working`, `blocked`, or `done` transition is observed within five seconds
- add regression coverage and changelog entry

## Problem

On Pi 0.82.1 with HerdR 0.7.5, some child panes started successfully and received the complete multiline task prompt, but remained `idle` with that prompt still in the editor. Sending one additional Enter immediately changed the child to `working`.

A fixed delay between `send-text` and Enter reduced the frequency but did not eliminate it. The launch path had no acknowledgement that the submit key caused an agent state transition.

## Approach

Start `herdr agent wait` before sending Enter so the state transition cannot be missed. If HerdR reports a wait timeout, send one additional Enter. Other wait failures remain fatal.

The retry is conditional, avoiding an unconditional second submission when the first Enter works.

## Verification

- `npm test` — 58/58 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- manually reproduced pending-editor state on `general` and `reviewer` children
- verified an additional Enter transitions affected children from `idle` to `working`
- tested patched extension locally over repeated subagent launches
