### PR TITLE
feat: add task-local fast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Optional task-local `fast` mode for configured OpenAI/OpenAI-Codex children. Fast mode applies the priority service tier without changing the selected model or thinking level, writing shared configuration, or affecting unsupported models.
+
 ## [0.4.3] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ For the full high-quality 89s @ 56 fps version, [download the MP4](https://githu
 - Background tasks: parent continues, task widget shows progress, completion arrives as a follow-up.
 - Tmux backend for observable subagent panes.
 - HerdR and tmux terminal backends, with SDK fallback when neither is available.
-- Agent frontmatter support: `model`, `thinking`, `skills`, `tools`, `disallowed_tools`.
+- Agent frontmatter support: `model`, `thinking`, `fast`, `skills`, `tools`, `disallowed_tools`.
+- Task-local OpenAI/OpenAI-Codex Fast Mode: apply priority service tier to configured models without changing model, thinking level, or shared configuration.
 - Built-in starter agents: `scout`, `explore`, `general`, `reviewer`.
 - Project/user agent overrides via `.pi/agents/*.md` or `~/.pi/agent/agents/*.md`.
 
@@ -45,6 +46,21 @@ Prompt contract for every non-trivial task:
 - write/read policy: whether the child may edit or must stay read-only
 - acceptance criteria and stop condition: observable conditions that must be true before stopping
 - verification recipe: checks to run or evidence to gather
+
+Task-local Fast Mode is optional. Set `fast: true` or `fast: false` on a start/resume request; when omitted, the selected agent's optional `fast:` frontmatter value applies, then behavior defaults to `false`.
+
+```json
+{
+  "operation": "start",
+  "agent_type": "general",
+  "description": "Implement focused fix",
+  "fast": true,
+  "background": false,
+  "prompt": "Goal: implement the bounded fix. Non-goals: do not change the model or thinking level. Write/read policy: edit only the requested files. Acceptance criteria: tests pass. Stop condition: the fix is verified. Verification: run the focused tests."
+}
+```
+
+When effective Fast Mode is enabled, a configured OpenAI or OpenAI-Codex child uses `serviceTier: "priority"` when its model is listed in `pi-codex-fast.json` under the Pi agent directory. The config's `enabled` value is not consulted, and pi-task never writes the file. Unsupported or unlisted models use their normal streamer. Terminal children use an isolated provider bridge; SDK children inject the same bridge while keeping normal extension discovery disabled.
 
 A reviewer request with missing parent_context or proposed_changes is rejected. If there are no design changes, pass an explicit item such as “No proposed design changes; assess the implementation against the stated goal.”
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Task-local Fast Mode is optional. Set `fast: true` or `fast: false` on a start/r
 }
 ```
 
-When effective Fast Mode is enabled, a configured OpenAI or OpenAI-Codex child uses `serviceTier: "priority"` when its model is listed in `pi-codex-fast.json` under the Pi agent directory. The config's `enabled` value is not consulted, and pi-task never writes the file. Unsupported or unlisted models use their normal streamer. Terminal children use an isolated provider bridge; SDK children inject the same bridge while keeping normal extension discovery disabled.
+When effective Fast Mode is enabled, a configured OpenAI or OpenAI-Codex child uses `serviceTier: "priority"` when its model is listed in `pi-codex-fast.json` under the Pi agent directory. The config's `enabled` value is not consulted, and pi-task never writes the file. If that file is missing or invalid, the built-in fallback list applies: `openai/gpt-5.4`, `openai/gpt-5.5`, `openai-codex/gpt-5.4`, `openai-codex/gpt-5.5` (same behavior as pi-codex-fast). Unsupported or unlisted models use their normal streamer. Terminal children use an isolated provider bridge; SDK children inject the same bridge while keeping normal extension discovery disabled.
 
 A reviewer request with missing parent_context or proposed_changes is rejected. If there are no design changes, pass an explicit item such as “No proposed design changes; assess the implementation against the stated goal.”
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "pi-task": "dist/index.js"
       },
       "devDependencies": {
+        "@earendil-works/pi-ai": "^0.84.1",
         "@earendil-works/pi-coding-agent": "^0.84.1",
         "@earendil-works/pi-tui": "^0.84.1",
         "@types/node": "^20.0.0",
@@ -20,9 +21,527 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
+        "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*",
         "typebox": "*"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.33.tgz",
+      "integrity": "sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.28.tgz",
+      "integrity": "sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.51.tgz",
+      "integrity": "sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
@@ -2032,6 +2551,16 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-tui": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
@@ -2488,6 +3017,266 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.43",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
@@ -2496,6 +3285,106 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/esbuild": {
@@ -2540,6 +3429,50 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2555,6 +3488,36 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -2568,6 +3531,116 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/marked": {
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -2580,6 +3653,165 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.4",
@@ -2627,6 +3859,58 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-ai": "^0.84.1",
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*",
         "typebox": "*"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-ai": "^0.84.1",
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*",
     "typebox": "*"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/helpers.test.ts test/prompt.test.ts test/frontmatter.test.ts test/renderHint.test.ts test/polling.test.ts test/taskWidget.test.ts test/sdkWidgetEvents.test.ts test/sdkBackground.test.ts test/sdkPolling.test.ts test/widgetLifecycle.test.ts test/handles.test.ts test/terminalBackend.test.ts test/herdrBackend.test.ts test/exitSentinel.test.ts test/waitCompletion.test.ts test/restore.test.ts test/lifecycleCompletion.test.ts test/failure-diagnostics.test.ts test/taskTitle.test.ts test/modelSelection.test.ts test/taskAdmission.test.ts test/taskControl.test.ts",
+    "test": "tsx --test test/helpers.test.ts test/prompt.test.ts test/frontmatter.test.ts test/renderHint.test.ts test/polling.test.ts test/taskWidget.test.ts test/sdkWidgetEvents.test.ts test/sdkBackground.test.ts test/sdkPolling.test.ts test/widgetLifecycle.test.ts test/handles.test.ts test/terminalBackend.test.ts test/herdrBackend.test.ts test/exitSentinel.test.ts test/waitCompletion.test.ts test/restore.test.ts test/lifecycleCompletion.test.ts test/failure-diagnostics.test.ts test/taskTitle.test.ts test/modelSelection.test.ts test/taskAdmission.test.ts test/taskControl.test.ts test/fastMode.test.ts",
     "smoke": "tsx test/smoke.ts",
     "prepack": "npm run build",
     "postversion": "git push --follow-tags"
@@ -44,11 +44,13 @@
   ],
   "license": "MIT",
   "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*",
     "typebox": "*"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "^0.84.1",
     "@earendil-works/pi-coding-agent": "^0.84.1",
     "@earendil-works/pi-tui": "^0.84.1",
     "@types/node": "^20.0.0",

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  clampThinkingLevel,
+  type Api,
+  type AssistantMessageEventStream,
+  type Context,
+  type Model,
+  type OpenAICodexResponsesOptions,
+  type OpenAIResponsesOptions,
+  type SimpleStreamOptions,
+  type ThinkingLevel,
+} from "@earendil-works/pi-ai";
+import {
+  stream as streamOpenAICodexResponses,
+  streamSimple as streamSimpleOpenAICodexResponses,
+} from "@earendil-works/pi-ai/api/openai-codex-responses";
+import { buildBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
+import {
+  stream as streamOpenAIResponses,
+  streamSimple as streamSimpleOpenAIResponses,
+} from "@earendil-works/pi-ai/api/openai-responses";
+import {
+  getAgentDir,
+  type ExtensionAPI,
+  type InlineExtension,
+} from "@earendil-works/pi-coding-agent";
+
+/**
+ * Task-local adaptation of pi-codex-fast v1.1.0's provider bridge.
+ * It deliberately omits that extension's command, status UI, and config writes.
+ */
+const DEFAULT_FAST_MODELS = [
+  "openai/gpt-5.4",
+  "openai/gpt-5.5",
+  "openai-codex/gpt-5.4",
+  "openai-codex/gpt-5.5",
+] as const;
+
+interface TaskFastModeConfig {
+  models: string[];
+}
+
+export interface TaskFastModeStreamers {
+  streamOpenAIResponses: (
+    model: Model<"openai-responses">,
+    context: Context,
+    options?: OpenAIResponsesOptions,
+  ) => AssistantMessageEventStream;
+  streamSimpleOpenAIResponses: (
+    model: Model<"openai-responses">,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ) => AssistantMessageEventStream;
+  streamOpenAICodexResponses: (
+    model: Model<"openai-codex-responses">,
+    context: Context,
+    options?: OpenAICodexResponsesOptions,
+  ) => AssistantMessageEventStream;
+  streamSimpleOpenAICodexResponses: (
+    model: Model<"openai-codex-responses">,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ) => AssistantMessageEventStream;
+}
+
+export interface TaskFastModeBridgeDeps {
+  agentDir?: string;
+  streamers?: Partial<TaskFastModeStreamers>;
+}
+
+const DEFAULT_STREAMERS: TaskFastModeStreamers = {
+  streamOpenAIResponses,
+  streamSimpleOpenAIResponses,
+  streamOpenAICodexResponses,
+  streamSimpleOpenAICodexResponses,
+};
+
+function normalizeModels(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const models = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const normalized = entry.trim().toLowerCase();
+    if (normalized) models.add(normalized);
+  }
+  return [...models];
+}
+
+function loadTaskFastModeConfig(agentDir: string): TaskFastModeConfig {
+  const configPath = join(agentDir, "extensions", "pi-codex-fast.json");
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const config = parsed as Record<string, unknown>;
+      return {
+        models: "models" in config
+          ? normalizeModels(config.models)
+          : [...DEFAULT_FAST_MODELS],
+      };
+    }
+  } catch {
+    // Match pi-codex-fast's invalid/missing-config fallback without creating a file.
+  }
+  return { models: [...DEFAULT_FAST_MODELS] };
+}
+
+function isConfiguredModel(
+  config: TaskFastModeConfig,
+  model: Pick<Model<Api>, "provider" | "id">,
+): boolean {
+  if (model.provider !== "openai" && model.provider !== "openai-codex") return false;
+  const bare = model.id.trim().toLowerCase();
+  const qualified = `${model.provider}/${model.id}`.trim().toLowerCase();
+  return config.models.some((entry) => entry === bare || entry === qualified);
+}
+
+function mapReasoningEffort(
+  model: Model<Api>,
+  reasoning: ThinkingLevel | undefined,
+): ThinkingLevel | undefined {
+  const clamped = reasoning ? clampThinkingLevel(model, reasoning) : undefined;
+  return clamped === "off" ? undefined : clamped;
+}
+
+export function createTaskFastModeStream(
+  agentDir: string,
+  streamers: TaskFastModeStreamers,
+) {
+  return (
+    model: Model<Api>,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ): AssistantMessageEventStream => {
+    const applyFast = isConfiguredModel(loadTaskFastModeConfig(agentDir), model);
+
+    if (model.api === "openai-responses") {
+      const openAIModel = model as Model<"openai-responses">;
+      if (!applyFast) {
+        return streamers.streamSimpleOpenAIResponses(openAIModel, context, options);
+      }
+      return streamers.streamOpenAIResponses(openAIModel, context, {
+        ...buildBaseOptions(model, context, options, options?.apiKey),
+        reasoningEffort: mapReasoningEffort(model, options?.reasoning),
+        serviceTier: "priority",
+      });
+    }
+
+    if (model.api === "openai-codex-responses") {
+      const codexModel = model as Model<"openai-codex-responses">;
+      if (!applyFast) {
+        return streamers.streamSimpleOpenAICodexResponses(codexModel, context, options);
+      }
+      return streamers.streamOpenAICodexResponses(codexModel, context, {
+        ...buildBaseOptions(model, context, options, options?.apiKey),
+        reasoningEffort: mapReasoningEffort(model, options?.reasoning),
+        serviceTier: "priority",
+      });
+    }
+
+    throw new Error(`pi-task fast mode: unsupported API for provider override: ${String(model.api)}`);
+  };
+}
+
+export function registerTaskFastModeBridge(
+  pi: ExtensionAPI,
+  deps: TaskFastModeBridgeDeps = {},
+): void {
+  const agentDir = deps.agentDir ?? getAgentDir();
+  const streamers = { ...DEFAULT_STREAMERS, ...deps.streamers };
+  const streamSimple = createTaskFastModeStream(agentDir, streamers);
+  const registerProviders = () => {
+    pi.registerProvider("openai", {
+      api: "openai-responses",
+      streamSimple,
+    });
+    pi.registerProvider("openai-codex", {
+      api: "openai-codex-responses",
+      streamSimple,
+    });
+  };
+
+  registerProviders();
+  // Re-apply after all extension-load registrations so explicit task fast wins
+  // over a globally installed pi-codex-fast without changing its configuration.
+  pi.on("session_start", registerProviders);
+}
+
+export function createTaskFastModeInlineExtension(agentDir: string): InlineExtension {
+  return {
+    name: "pi-task-fast-mode",
+    factory: (pi) => registerTaskFastModeBridge(pi, { agentDir }),
+  };
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,15 +20,18 @@ function parseMarkdownFrontmatter(content: string): {
   frontmatter: Record<string, string>;
   body: string;
 } {
-  if (!content.startsWith("---\n")) {
+  // Git checkouts on Windows may provide CRLF agent files; parse the same
+  // frontmatter contract regardless of checkout line endings.
+  const normalizedContent = content.replace(/\r\n/g, "\n");
+  if (!normalizedContent.startsWith("---\n")) {
     return { frontmatter: {}, body: content };
   }
 
-  const end = content.indexOf("\n---", 4);
+  const end = normalizedContent.indexOf("\n---", 4);
   if (end === -1) return { frontmatter: {}, body: content };
 
-  const raw = content.slice(4, end).trim();
-  const body = content.slice(end + "\n---".length).replace(/^\n/, "");
+  const raw = normalizedContent.slice(4, end).trim();
+  const body = normalizedContent.slice(end + "\n---".length).replace(/^\n/, "");
   const frontmatter: Record<string, string> = {};
 
   for (const line of raw.split("\n")) {
@@ -49,6 +52,8 @@ export interface AgentConfig {
   description: string;
   model?: string;
   thinking?: string;
+  /** Optional Fast Mode default from frontmatter `fast:`. */
+  fast?: boolean;
   /** Skill names from frontmatter `skills:`; resolved to paths before launch. */
   skills?: string[];
   /** Explicit allowlist from frontmatter `tools:` */
@@ -501,6 +506,7 @@ export function loadAgentsFromDir(
     const hidden = parseBool(frontmatter.hidden);
     const proactive = parseBool(frontmatter.proactive);
     const readonly = parseBool(frontmatter.readonly);
+    const fast = parseBool(frontmatter.fast);
     // Always-on xAI disallow list — these tools are never useful for
     // task subagents and risk leaking provider-specific behavior.
     const withDefaults = [
@@ -520,6 +526,7 @@ export function loadAgentsFromDir(
       description: frontmatter.description,
       model: frontmatter.model,
       thinking: frontmatter.thinking,
+      fast,
       skills: skills.length > 0 ? skills : undefined,
       tools: tools.length > 0 ? tools : undefined,
       disallowedTools,
@@ -578,6 +585,13 @@ export function parseBool(value: unknown): boolean | undefined {
   if (value === false || value === "false" || value === "no" || value === "0")
     return false;
   return undefined;
+}
+
+export function resolveTaskFastMode(
+  taskFast: boolean | undefined,
+  agentFast: boolean | undefined,
+): boolean {
+  return taskFast ?? agentFast ?? false;
 }
 
 function isAgentHidden(agent: AgentConfig): boolean {
@@ -672,6 +686,8 @@ export function formatAgentList(agents: AgentConfig[]): string {
       resumeSessionRef?: string,
       promptLaunch?: PiPromptLaunchOptions,
       skillPaths?: string[],
+      fast?: boolean,
+      fastExtensionPath?: string,
     ): string[] {
       return buildPiArgv({
         agent,
@@ -684,6 +700,8 @@ export function formatAgentList(agents: AgentConfig[]): string {
         taskToolName,
         promptLaunch,
         skillPaths,
+        fast,
+        fastExtensionPath,
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,14 +122,17 @@ const BUNDLED_AGENT_DIR = join(
 // ─── Extension Entry Point ──────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
+  // Register in both branches so a manual `pi -e pi-task --fast` in a normal
+  // session is accepted instead of dying as "Unknown option: --fast". The
+  // bridge is only installed in the disabled recursive-child branch below.
+  pi.registerFlag("fast", {
+    description: "Use priority service tier for this delegated child",
+    type: "boolean",
+    default: false,
+  });
   // Recursive children never register task. An explicitly fast terminal child
   // loads this same extension path only to install its isolated provider bridge.
   if (process.env.PI_TASK_TOOL_DISABLED === "1") {
-    pi.registerFlag("fast", {
-      description: "Use priority service tier for this delegated child",
-      type: "boolean",
-      default: false,
-    });
     let fastModeBridgeInstalled = false;
     pi.on("session_start", () => {
       if (fastModeBridgeInstalled || pi.getFlag("fast") !== true) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,9 @@ import {
   MAX_POLL_ERRORS,
   TASK_TIMEOUT_MS,
 } from "./constants.js";
+import { registerTaskFastModeBridge } from "./fast-mode.js";
+export { createTaskFastModeStream, registerTaskFastModeBridge } from "./fast-mode.js";
+export type { TaskToolParameters } from "./tool/schema.js";
 import {
   findJsonlSessionByName,
   normalizeConversationId,
@@ -47,6 +50,7 @@ import {
       discoverAgents,
       subscribeToolEvents,
   resolveTaskAgentPreflight,
+  resolveTaskFastMode,
   assessTaskResult,
   buildTaskEnvelope,
   completionDeliveryOptions,
@@ -107,8 +111,9 @@ import {
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
+const TASK_EXTENSION_PATH = fileURLToPath(import.meta.url);
 const BUNDLED_AGENT_DIR = join(
-  dirname(fileURLToPath(import.meta.url)),
+  dirname(TASK_EXTENSION_PATH),
   "..",
   "agents",
 );
@@ -117,8 +122,22 @@ const BUNDLED_AGENT_DIR = join(
 // ─── Extension Entry Point ──────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
-  // Prevent recursive loading
-  if (process.env.PI_TASK_TOOL_DISABLED === "1") return;
+  // Recursive children never register task. An explicitly fast terminal child
+  // loads this same extension path only to install its isolated provider bridge.
+  if (process.env.PI_TASK_TOOL_DISABLED === "1") {
+    pi.registerFlag("fast", {
+      description: "Use priority service tier for this delegated child",
+      type: "boolean",
+      default: false,
+    });
+    let fastModeBridgeInstalled = false;
+    pi.on("session_start", () => {
+      if (fastModeBridgeInstalled || pi.getFlag("fast") !== true) return;
+      fastModeBridgeInstalled = true;
+      registerTaskFastModeBridge(pi);
+    });
+    return;
+  }
 
   const taskToolName = process.env.PI_TASK_TOOL_NAME?.trim() || "task";
   if (!/^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(taskToolName)) {
@@ -713,6 +732,7 @@ export default function (pi: ExtensionAPI) {
           details: { phase: "failed" as const, error },
         };
       }
+      const effectiveFast = resolveTaskFastMode(taskParams.fast, agent.fast);
       let promptLaunch:
         | { systemPromptPath: string; deferTaskPrompt: boolean }
         | undefined;
@@ -734,6 +754,8 @@ export default function (pi: ExtensionAPI) {
         resumeSessionRef,
         promptLaunch,
         skillPaths,
+        effectiveFast,
+        TASK_EXTENSION_PATH,
       );
       const useSdkBackend = selectedBackend === "sdk";
 
@@ -761,6 +783,7 @@ export default function (pi: ExtensionAPI) {
               excludeTools: toolSelection.excludeTools,
               systemPrompt: agent.body,
               skillPaths,
+              fast: effectiveFast,
             });
 
       const foregroundTask: BackgroundTask | undefined = isBackground

--- a/src/subagent/buildArgv.ts
+++ b/src/subagent/buildArgv.ts
@@ -22,6 +22,8 @@ export interface BuildPiArgvOptions {
   promptLaunch?: PiPromptLaunchOptions;
   /** Absolute skill paths passed to Pi's repeatable --skill option. */
   skillPaths?: string[];
+  fast?: boolean;
+  fastExtensionPath?: string;
 }
 
 export function buildPiArgv(opts: BuildPiArgvOptions): string[] {
@@ -35,8 +37,14 @@ export function buildPiArgv(opts: BuildPiArgvOptions): string[] {
   });
 
   const args: string[] = [];
-  if (process.env.PI_TASK_CHILD_NO_EXTENSIONS === "1") {
+  if (opts.fast || process.env.PI_TASK_CHILD_NO_EXTENSIONS === "1") {
     args.push("--no-extensions");
+  }
+  if (opts.fast) {
+    if (!opts.fastExtensionPath) {
+      throw new Error("Fast task launch requires the pi-task extension path");
+    }
+    args.push("--extension", opts.fastExtensionPath, "--fast");
   }
   if (agent.model) args.push("--model", agent.model);
   if (agent.thinking) args.push("--thinking", agent.thinking);

--- a/src/subagent/runSdk.ts
+++ b/src/subagent/runSdk.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { createTaskFastModeInlineExtension } from "../fast-mode.js";
 import type { AgentConfig } from "../helpers.js";
 
 export interface RunSdkSubagentOptions {
@@ -12,6 +13,7 @@ export interface RunSdkSubagentOptions {
   excludeTools?: string[];
   systemPrompt?: string;
   skillPaths?: string[];
+  fast?: boolean;
   /**
    * Called with the AgentSession after creation but before prompt().
    * Return an unsubscribe function that will be called on cleanup.
@@ -25,6 +27,7 @@ export function buildSdkResourceLoaderOptions(options: {
   settingsManager: SettingsManager;
   systemPrompt?: string;
   skillPaths?: string[];
+  fast?: boolean;
 }) {
   return {
     cwd: options.cwd,
@@ -33,6 +36,9 @@ export function buildSdkResourceLoaderOptions(options: {
     systemPromptOverride: () => options.systemPrompt,
     additionalSkillPaths: options.skillPaths,
     noExtensions: true,
+    extensionFactories: options.fast
+      ? [createTaskFastModeInlineExtension(options.agentDir)]
+      : [],
   };
 }
 
@@ -96,6 +102,7 @@ export async function runSdkSubagent(options: RunSdkSubagentOptions): Promise<{
         settingsManager,
         systemPrompt: options.systemPrompt,
         skillPaths: options.skillPaths,
+        fast: options.fast,
       }) as any,
     );
 

--- a/src/task-control.ts
+++ b/src/task-control.ts
@@ -30,6 +30,7 @@ export interface TaskStartRequest {
   cwd?: string;
   task_id?: string;
   conversation_id?: string;
+  fast?: boolean;
   background?: boolean;
 }
 
@@ -162,6 +163,9 @@ export function parseTaskStartRequest(value: unknown): TaskStartRequest | undefi
   )) {
     return undefined;
   }
+  if (candidate.fast !== undefined && typeof candidate.fast !== "boolean") {
+    return undefined;
+  }
   if (candidate.background !== undefined && typeof candidate.background !== "boolean") {
     return undefined;
   }
@@ -202,6 +206,7 @@ export function parseTaskStartRequest(value: unknown): TaskStartRequest | undefi
     ...(typeof candidate.cwd === "string" ? { cwd: candidate.cwd } : {}),
     ...(typeof candidate.task_id === "string" ? { task_id: candidate.task_id } : {}),
     ...(typeof candidate.conversation_id === "string" ? { conversation_id: candidate.conversation_id } : {}),
+    ...(typeof candidate.fast === "boolean" ? { fast: candidate.fast } : {}),
     ...(typeof candidate.background === "boolean" ? { background: candidate.background } : {}),
   };
 }

--- a/src/tool/schema.ts
+++ b/src/tool/schema.ts
@@ -58,7 +58,7 @@ export function taskParametersSchema() {
     fast: Type.Optional(
       Type.Boolean({
         description:
-          "Use OpenAI/OpenAI-Codex priority service tier for this child when its model is listed in pi-codex-fast configuration. When omitted, the agent frontmatter fast value applies; otherwise behavior defaults to false. Does not change model or thinking level.",
+          "Use OpenAI/OpenAI-Codex priority service tier for this child when its model is listed in pi-codex-fast configuration; a missing or invalid config falls back to the built-in gpt-5.4/gpt-5.5 model list. When omitted, the agent frontmatter fast value applies; otherwise behavior defaults to false. Does not change model or thinking level.",
       }),
     ),
     background: Type.Optional(

--- a/src/tool/schema.ts
+++ b/src/tool/schema.ts
@@ -1,4 +1,4 @@
-import { Type } from "typebox";
+import { Type, type Static } from "typebox";
 
 export function taskParametersSchema() {
   // Keep a single object at the schema root. Pi's Anthropic adapter reads
@@ -55,6 +55,12 @@ export function taskParametersSchema() {
     cwd: Type.Optional(Type.String({
       description: "Absolute existing directory where a newly launched child runs. Use a parent-created Git worktree for writer isolation. Defaults to the caller cwd; resumed launches reuse their stored cwd. pi-task does not create, merge, or remove the worktree.",
     })),
+    fast: Type.Optional(
+      Type.Boolean({
+        description:
+          "Use OpenAI/OpenAI-Codex priority service tier for this child when its model is listed in pi-codex-fast configuration. When omitted, the agent frontmatter fast value applies; otherwise behavior defaults to false. Does not change model or thinking level.",
+      }),
+    ),
     background: Type.Optional(
       Type.Boolean({
         description:
@@ -64,3 +70,5 @@ export function taskParametersSchema() {
     ),
   });
 }
+
+export type TaskToolParameters = Static<ReturnType<typeof taskParametersSchema>>;

--- a/test/failure-diagnostics.test.ts
+++ b/test/failure-diagnostics.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import {
   enrichSubagentFailureMessage,
@@ -9,7 +10,7 @@ describe("failure diagnostics", () => {
   it("builds task-scoped session paths", () => {
     assert.equal(
       sessionDirForTask("/tmp/artifacts", "task-123"),
-      "/tmp/artifacts/sessions/task-123",
+      join("/tmp/artifacts", "sessions", "task-123"),
     );
   });
 
@@ -24,7 +25,7 @@ describe("failure diagnostics", () => {
 
     assert.match(result, /Subagent pane exited/);
     assert.match(result, /Session dir:/);
-    assert.match(result, /sessions\/task-99/);
+    assert.match(result, /sessions[\\/]task-99/);
     assert.match(result, /Session JSONL: missing/);
     assert.match(result, /PI_TASK_CHILD_NO_EXTENSIONS/);
   });

--- a/test/fastMode.test.ts
+++ b/test/fastMode.test.ts
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { buildBaseOptions as buildNativeBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
+import taskExtension, * as taskModule from "../src/index.js";
+import {
+  createAgentSessionFromServices,
+  createAgentSessionServices,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import { createTaskFastModeStream } from "../src/fast-mode.js";
+import type { AgentConfig } from "../src/helpers.js";
+import {
+  buildPiArgv,
+  type BuildPiArgvOptions,
+} from "../src/subagent/buildArgv.js";
+import {
+  buildSdkResourceLoaderOptions,
+} from "../src/subagent/runSdk.js";
+import { taskParametersSchema } from "../src/tool/schema.js";
+
+const agent: AgentConfig = {
+  name: "test",
+  description: "test agent",
+  body: "",
+  source: "bundled",
+  path: "/agents/test.md",
+};
+
+const baseArgvOptions: BuildPiArgvOptions = {
+  agent,
+  sessionName: "task-fast-test",
+  sessionDir: "/tmp/task-fast-test",
+  promptContent: "perform the task",
+};
+
+function createFastStreamHarness(models: string[]) {
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-task-fast-options-"));
+  const configDir = join(agentDir, "extensions");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "pi-codex-fast.json"), JSON.stringify({ models }));
+
+  const calls: Array<{ model: unknown; context: unknown; options: Record<string, unknown> }> = [];
+  const capture = (model: unknown, context: unknown, options: unknown) => {
+    calls.push({ model, context, options: options as Record<string, unknown> });
+    return {} as never;
+  };
+  const stream = createTaskFastModeStream(agentDir, {
+    streamOpenAIResponses: capture,
+    streamSimpleOpenAIResponses: capture,
+    streamOpenAICodexResponses: capture,
+    streamSimpleOpenAICodexResponses: capture,
+  });
+  return { agentDir, calls, stream };
+}
+
+test("task schema advertises an optional fast boolean", () => {
+  const schema = taskParametersSchema() as {
+    properties?: Record<string, { type?: string; description?: string; default?: boolean }>;
+    required?: string[];
+  };
+  const fast = schema.properties?.fast;
+
+  assert.ok(fast);
+  assert.equal(fast.type, "boolean");
+  assert.match(fast.description ?? "", /priority service tier/i);
+  assert.equal(fast.default, undefined);
+  assert.equal(Boolean(schema.required?.includes("fast")), false);
+});
+
+test("terminal argv isolates every fast task and preserves env-controlled isolation", () => {
+  const previousNoExtensions = process.env.PI_TASK_CHILD_NO_EXTENSIONS;
+  const options = {
+    ...baseArgvOptions,
+    fast: true,
+    fastExtensionPath: "/fork/dist/index.js",
+  } as BuildPiArgvOptions & { fast: boolean; fastExtensionPath: string };
+
+  try {
+    delete process.env.PI_TASK_CHILD_NO_EXTENSIONS;
+    const fastArgs = buildPiArgv(options);
+    const normalArgs = buildPiArgv({ ...options, fast: false });
+
+    const extensionIndex = fastArgs.indexOf("--extension");
+    assert.notEqual(extensionIndex, -1);
+    assert.deepEqual(
+      fastArgs.slice(extensionIndex, extensionIndex + 3),
+      ["--extension", "/fork/dist/index.js", "--fast"],
+    );
+    assert.equal(fastArgs.filter((arg) => arg === "--no-extensions").length, 1);
+    assert.equal(normalArgs.filter((arg) => arg === "--no-extensions").length, 0);
+    assert.equal(normalArgs.includes("--fast"), false);
+    assert.equal(normalArgs.includes("/fork/dist/index.js"), false);
+    assert.equal(fastArgs.includes("--model"), false);
+    assert.equal(fastArgs.includes("--thinking"), false);
+
+    process.env.PI_TASK_CHILD_NO_EXTENSIONS = "1";
+    const fastArgsWithEnv = buildPiArgv(options);
+    const normalArgsWithEnv = buildPiArgv({ ...options, fast: false });
+    assert.equal(fastArgsWithEnv.filter((arg) => arg === "--no-extensions").length, 1);
+    assert.equal(normalArgsWithEnv.filter((arg) => arg === "--no-extensions").length, 1);
+  } finally {
+    if (previousNoExtensions === undefined) delete process.env.PI_TASK_CHILD_NO_EXTENSIONS;
+    else process.env.PI_TASK_CHILD_NO_EXTENSIONS = previousNoExtensions;
+  }
+});
+
+test("PI_TASK_TOOL_DISABLED child registers fast providers after real flag application and startup", async () => {
+  const previousDisabled = process.env.PI_TASK_TOOL_DISABLED;
+  process.env.PI_TASK_TOOL_DISABLED = "1";
+  const cwd = mkdtempSync(join(tmpdir(), "pi-task-fast-cwd-"));
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-task-fast-agent-"));
+
+  try {
+    const services = await createAgentSessionServices({
+      cwd,
+      agentDir,
+      extensionFlagValues: new Map([["fast", true]]),
+      resourceLoaderOptions: {
+        noExtensions: true,
+        extensionFactories: [{ name: "pi-task-terminal", factory: taskExtension }],
+      },
+    });
+
+    // The old factory-time getFlag() read leaves the bridge absent here and after startup.
+    assert.deepEqual(services.modelRuntime.getRegisteredProviderIds(), []);
+
+    const { session } = await createAgentSessionFromServices({
+      services,
+      sessionManager: SessionManager.inMemory(cwd),
+      noTools: "all",
+    });
+    try {
+      await session.bindExtensions({});
+      assert.deepEqual(
+        new Set(services.modelRuntime.getRegisteredProviderIds()),
+        new Set(["openai", "openai-codex"]),
+      );
+      assert.equal(
+        services.modelRuntime.getRegisteredProviderConfig("openai")?.api,
+        "openai-responses",
+      );
+      assert.equal(
+        services.modelRuntime.getRegisteredProviderConfig("openai-codex")?.api,
+        "openai-codex-responses",
+      );
+    } finally {
+      session.dispose();
+    }
+  } finally {
+    if (previousDisabled === undefined) delete process.env.PI_TASK_TOOL_DISABLED;
+    else process.env.PI_TASK_TOOL_DISABLED = previousDisabled;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("SDK loader keeps extensions disabled and injects fast bridge only when requested", () => {
+  const fast = buildSdkResourceLoaderOptions({
+    cwd: "/repo",
+    agentDir: "/agent",
+    settingsManager: {} as never,
+    systemPrompt: "child prompt",
+    fast: true,
+  });
+  const normal = buildSdkResourceLoaderOptions({
+    cwd: "/repo",
+    agentDir: "/agent",
+    settingsManager: {} as never,
+    systemPrompt: "child prompt",
+    fast: false,
+  });
+
+  assert.equal(fast.noExtensions, true);
+  assert.equal(fast.extensionFactories?.length, 1);
+  assert.equal(fast.extensionFactories?.[0]?.name, "pi-task-fast-mode");
+  assert.equal(normal.noExtensions, true);
+  assert.deepEqual(normal.extensionFactories ?? [], []);
+});
+
+test("configured fast models preserve native options and add only priority", () => {
+  const { agentDir, calls, stream } = createFastStreamHarness([
+    "openai/gpt-fast",
+    "openai-codex/gpt-fast",
+  ]);
+  const openAIModel = {
+    provider: "openai",
+    id: "gpt-fast",
+    api: "openai-responses",
+    maxTokens: 131_072,
+    contextWindow: 400_000,
+    reasoning: true,
+  };
+  const codexModel = {
+    ...openAIModel,
+    provider: "openai-codex",
+    api: "openai-codex-responses",
+  };
+  const context = { messages: [] };
+  const options = {
+    reasoning: "high" as const,
+    maxTokens: 20_000,
+    apiKey: "test-key",
+    env: { HTTPS_PROXY: "http://proxy.test" },
+    websocketConnectTimeoutMs: 12_345,
+  };
+
+  try {
+    stream(openAIModel as never, context, options);
+    stream(codexModel as never, context, options);
+
+    assert.equal(calls[0]?.model, openAIModel);
+    assert.equal(calls[1]?.model, codexModel);
+    assert.deepEqual(calls[0]?.options, {
+      ...buildNativeBaseOptions(openAIModel as never, context, options, options.apiKey),
+      reasoningEffort: "high",
+      serviceTier: "priority",
+    });
+    assert.deepEqual(calls[1]?.options, {
+      ...buildNativeBaseOptions(codexModel as never, context, options, options.apiKey),
+      reasoningEffort: "high",
+      serviceTier: "priority",
+    });
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("unlisted and unsupported models use their normal streamer", () => {
+  const { agentDir, calls, stream } = createFastStreamHarness(["openai/gpt-fast"]);
+  const model = {
+    provider: "openai",
+    id: "gpt-normal",
+    api: "openai-responses",
+    maxTokens: 64_000,
+    contextWindow: 400_000,
+    reasoning: true,
+  };
+  const unsupported = {
+    provider: "anthropic",
+    id: "gpt-fast",
+    api: "openai-responses",
+    maxTokens: 64_000,
+    contextWindow: 400_000,
+    reasoning: true,
+  };
+
+  try {
+    const normalOptions = { reasoning: "low" as const };
+    const unsupportedOptions = { reasoning: "medium" as const };
+    const normalResult = stream(model as never, { messages: [] }, normalOptions);
+    const unsupportedResult = stream(unsupported as never, { messages: [] }, unsupportedOptions);
+
+    assert.ok(normalResult);
+    assert.ok(unsupportedResult);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.options, normalOptions);
+    assert.equal(calls[1]?.options, unsupportedOptions);
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("fast mode ignores config enabled and never writes config", () => {
+  const registerBridge = (
+    taskModule as unknown as {
+      registerTaskFastModeBridge?: (pi: unknown, deps: unknown) => void;
+    }
+  ).registerTaskFastModeBridge;
+  assert.equal(typeof registerBridge, "function");
+
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-task-fast-mode-"));
+  const configDir = join(agentDir, "extensions");
+  const configPath = join(configDir, "pi-codex-fast.json");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    configPath,
+    JSON.stringify({ enabled: false, models: ["openai/gpt-fast"] }, null, 2) + "\n",
+    "utf8",
+  );
+  const before = readFileSync(configPath, "utf8");
+  const priorityCalls: Array<Record<string, unknown>> = [];
+  const normalCalls: Array<Record<string, unknown>> = [];
+  const providers = new Map<string, { streamSimple: (...args: unknown[]) => unknown }>();
+  const resultToken = {};
+
+  try {
+    registerBridge!({
+      registerProvider(name: string, config: { streamSimple: (...args: unknown[]) => unknown }) {
+        providers.set(name, config);
+      },
+      on() {},
+    }, {
+      agentDir,
+      streamers: {
+        streamOpenAIResponses(_model: unknown, _context: unknown, options: Record<string, unknown>) {
+          priorityCalls.push(options);
+          return resultToken;
+        },
+        streamSimpleOpenAIResponses(_model: unknown, _context: unknown, options: Record<string, unknown>) {
+          normalCalls.push(options);
+          return resultToken;
+        },
+        streamOpenAICodexResponses() {
+          return resultToken;
+        },
+        streamSimpleOpenAICodexResponses() {
+          return resultToken;
+        },
+      },
+    });
+
+    const stream = providers.get("openai")?.streamSimple;
+    assert.ok(stream);
+    assert.equal(stream({
+      provider: "openai",
+      id: "gpt-fast",
+      api: "openai-responses",
+      maxTokens: 64_000,
+      reasoning: true,
+    }, { messages: [] }, { reasoning: "high", maxTokens: 1234 }), resultToken);
+    assert.equal(stream({
+      provider: "openai",
+      id: "gpt-normal",
+      api: "openai-responses",
+      maxTokens: 64_000,
+      reasoning: true,
+    }, { messages: [] }, { reasoning: "low" }), resultToken);
+
+    assert.equal(priorityCalls.length, 1);
+    assert.equal(priorityCalls[0]?.serviceTier, "priority");
+    assert.equal(priorityCalls[0]?.reasoningEffort, "high");
+    assert.equal(normalCalls.length, 1);
+    assert.equal(readFileSync(configPath, "utf8"), before);
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});

--- a/test/frontmatter.test.ts
+++ b/test/frontmatter.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadAgentsFromDir, parseBool } from "../src/helpers.js";
+import { loadAgentsFromDir, parseBool, resolveTaskFastMode } from "../src/helpers.js";
 
 {
   const t = "parseBool";
@@ -28,6 +28,7 @@ skills: memory, verification-before-completion
 hidden: true
 proactive: yes
 readonly: true
+fast: true
 ---
 Body.`,
     );
@@ -46,6 +47,7 @@ No description.`,
     assert.equal(a.hidden, true, t + " hidden");
     assert.equal(a.proactive, true, t + " proactive");
     assert.equal(a.readonly, true, t + " readonly");
+    assert.equal(a.fast, true, t + " fast");
       assert.deepEqual(a.skills, ["memory", "verification-before-completion"], t + " skills");
       assert.ok(
         !a.disallowedTools.includes("harness"),
@@ -55,6 +57,33 @@ No description.`,
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+}
+
+{
+  const t = "loadAgentsFromDir accepts CRLF frontmatter from Windows checkouts";
+  const root = mkdtempSync(join(tmpdir(), "task-fm-crlf-"));
+  try {
+    const dir = join(root, "agents");
+    mkdirSync(dir);
+    writeFileSync(
+      join(dir, "crlf.md"),
+      "---\r\ndescription: CRLF agent\r\nfast: true\r\n---\r\nBody.\r\n",
+    );
+    const agent = loadAgentsFromDir(dir, "bundled")[0];
+    assert.equal(agent?.description, "CRLF agent", t + " description");
+    assert.equal(agent?.fast, true, t + " fast");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+{
+  const t = "resolveTaskFastMode gives explicit task fast precedence over agent defaults";
+  assert.equal(resolveTaskFastMode(undefined, true), true, t + " omitted task uses agent true");
+  assert.equal(resolveTaskFastMode(undefined, false), false, t + " omitted task uses agent false");
+  assert.equal(resolveTaskFastMode(undefined, undefined), false, t + " omitted defaults false");
+  assert.equal(resolveTaskFastMode(true, false), true, t + " explicit true wins");
+  assert.equal(resolveTaskFastMode(false, true), false, t + " explicit false wins");
 }
 
 console.log("frontmatter.test.ts: all passed");

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -7,7 +7,7 @@
 import { strict as assert } from "node:assert";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
 import { resolveAgentToolAllowlist } from "../src/agent-tools.js";
 import {
   parseResultXml,
@@ -721,12 +721,9 @@ import {
 
 {
   const t = "findPiDir returns null when no .pi exists";
-  const root = mkdtempSync(join(tmpdir(), "task-test-findpi-null-"));
-  try {
-    assert.equal(findPiDir(join(root, "a", "b")), null, t);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  const filesystemRoot = parse(process.cwd()).root;
+  const missing = join(filesystemRoot, `task-test-findpi-null-${process.pid}`, "a", "b");
+  assert.equal(findPiDir(missing), null, t);
 }
 
 {

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -88,6 +88,7 @@ process.on("exit", () => {
       if (event === "session_shutdown") shutdown = handler;
     },
     registerMessageRenderer() {},
+      registerFlag() {},
     registerTool(value: typeof tool) {
       tool = value;
     },
@@ -195,6 +196,7 @@ if (process.platform !== "win32") {
         if (event === "session_shutdown") shutdown = handler;
       },
       registerMessageRenderer() {},
+      registerFlag() {},
       registerTool(value: typeof tool) {
         tool = value;
       },
@@ -259,6 +261,7 @@ if (process.platform !== "win32") {
         if (event === "session_shutdown") shutdown = handler;
       },
       registerMessageRenderer() {},
+      registerFlag() {},
       registerTool(value: typeof tool) {
         tool = value;
       },

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -137,7 +137,7 @@ process.on("exit", () => {
   }
 }
 
-{
+if (process.platform !== "win32") {
   const t = "active durable conversations reject foreground relaunch";
   const root = mkdtempSync(join(tmpdir(), "pi-task-active-cwd-"));
   const piDir = join(root, ".pi");
@@ -234,7 +234,7 @@ process.on("exit", () => {
   }
 }
 
-{
+if (process.platform !== "win32") {
   const t = "concurrent durable launches create one child";
   const root = mkdtempSync(join(tmpdir(), "pi-task-concurrent-cwd-"));
   const piDir = join(root, ".pi");

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -21,6 +21,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const PI_COMMAND = process.platform === "win32" ? "pi.cmd" : "pi";
+
 function assertPiMeetsPeerDependency(): void {
   const pkgPath = join(
     fileURLToPath(new URL("..", import.meta.url)),
@@ -31,7 +33,8 @@ function assertPiMeetsPeerDependency(): void {
   ] as string;
   let piVersion = "";
   try {
-    piVersion = execFileSync("pi", ["--version"], {
+    piVersion = execFileSync(PI_COMMAND, ["--version"], {
+      shell: process.platform === "win32",
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     }).trim();
@@ -241,7 +244,8 @@ try {
   const { execFileSync } = await import("node:child_process");
   // First, verify pi is available
   console.log("  pi version:");
-  const versionOut = execFileSync("pi", ["--version"], {
+  const versionOut = execFileSync(PI_COMMAND, ["--version"], {
+    shell: process.platform === "win32",
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
   }).trim();
@@ -254,7 +258,8 @@ try {
     string,
     string
   >;
-  const piVersionOut = execFileSync("pi", ["--version"], {
+  const piVersionOut = execFileSync(PI_COMMAND, ["--version"], {
+    shell: process.platform === "win32",
     env,
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],

--- a/test/taskControl.test.ts
+++ b/test/taskControl.test.ts
@@ -158,6 +158,7 @@ test("task tool explains malformed control payloads instead of reporting a gener
       if (event === "session_shutdown") shutdown = handler;
     },
     registerMessageRenderer() {},
+      registerFlag() {},
     registerTool(definition: CapturedTaskTool) {
       tool = definition;
     },

--- a/test/taskControl.test.ts
+++ b/test/taskControl.test.ts
@@ -81,6 +81,26 @@ test("task start parsing supplies runtime validation for the flat provider schem
   }), undefined);
 });
 
+test("fast is an optional start setting and survives task control parsing", () => {
+  const schema = taskParametersSchema();
+  const base = {
+    agent_type: "explore",
+    description: "Inspect the repository",
+    prompt: "Map the repository.",
+  };
+
+  assert.equal(Value.Check(schema, { ...base, fast: true }), true);
+  assert.equal(Value.Check(schema, { ...base, fast: false }), true);
+  assert.equal(parseTaskStartRequest({ ...base, fast: true })?.fast, true);
+  assert.equal(parseTaskStartRequest({ ...base, fast: false })?.fast, false);
+  assert.equal(parseTaskStartRequest({ ...base, fast: "true" }), undefined);
+  assert.equal(parseTaskControlRequest({
+    operation: "status",
+    task_id: "task-1",
+    fast: true,
+  }), undefined);
+});
+
 test("reviewer starts require structured parent context and proposed semantics", () => {
   const base = {
     agent_type: "reviewer",


### PR DESCRIPTION
## Summary

- Add optional task-level and agent-frontmatter `fast` controls with precedence `task > agent > false`.
- Add a task-local OpenAI/OpenAI-Codex bridge that requests `serviceTier: "priority"` only for configured models without mutating shared configuration.
- Isolate Fast Mode for terminal and SDK children while preserving existing v0.4.3 behavior, validation, tests, and documentation.

Related to #16

## Behavior / architecture

- Fast terminal children load the explicit pi-task bridge and pass exactly one `--no-extensions`.
- Fast terminal flag evaluation happens after Pi applies CLI values at session startup.
- Fast SDK children keep extension discovery disabled and inject one inline bridge.
- The bridge preserves model, thinking, and native options; it applies priority service tier only to configured OpenAI/OpenAI-Codex models.
- Shared Fast Mode configuration `enabled` is ignored for this task-local path, and the bridge never writes configuration.

## Compatibility

- `fast` defaults to `false` and normal non-fast tasks retain their existing behavior.
- Existing v0.4.3 start/status/cancel validation is preserved.
- No npm publish, production release, version bump, or upstream branch write is included.

## Verification

Verified on the accepted reviewer fingerprint:

- `npm run typecheck` — exit 0.
- Affected tests — 28 passed, 0 failed/skipped.
- `npm test` — 104 passed, 0 failed/skipped.
- `npm run build` — exit 0.
- `npm run smoke` — ALL SMOKE TESTS PASSED; Pi 0.84.1.
- `npm pack --dry-run --json` — exit 0; 92 package entries, including `dist/fast-mode.js` and its `.d.ts`.
- `git diff --check` — exit 0.

### Transparent smoke notes

- Smoke emitted Node `DEP0190` for the Windows `shell:true` `pi.cmd` invocation.
- The existing peer-caret check reported `SKIP` because the peer range is `*`.

Both notes are reported as-is; neither was hidden or converted into a false pass.