### PR TITLE
fix: resolve task sessions from artifact roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/helpers.test.ts test/prompt.test.ts test/frontmatter.test.ts test/renderHint.test.ts test/polling.test.ts test/taskWidget.test.ts test/sdkWidgetEvents.test.ts test/sdkBackground.test.ts test/sdkPolling.test.ts test/widgetLifecycle.test.ts test/handles.test.ts test/terminalBackend.test.ts test/herdrBackend.test.ts test/exitSentinel.test.ts test/waitCompletion.test.ts test/restore.test.ts test/lifecycleCompletion.test.ts test/failure-diagnostics.test.ts test/taskTitle.test.ts test/modelSelection.test.ts test/taskAdmission.test.ts test/taskControl.test.ts test/fastMode.test.ts test/panelCore.test.ts test/transcript.test.ts test/deliveryGuard.test.ts test/panelWidget.test.ts test/staleCtx.test.ts test/comparison.test.ts",
+    "test": "tsx --test test/helpers.test.ts test/prompt.test.ts test/frontmatter.test.ts test/renderHint.test.ts test/polling.test.ts test/taskWidget.test.ts test/sdkWidgetEvents.test.ts test/sdkBackground.test.ts test/sdkPolling.test.ts test/widgetLifecycle.test.ts test/handles.test.ts test/terminalBackend.test.ts test/herdrBackend.test.ts test/exitSentinel.test.ts test/waitCompletion.test.ts test/restore.test.ts test/lifecycleCompletion.test.ts test/failure-diagnostics.test.ts test/taskTitle.test.ts test/modelSelection.test.ts test/taskAdmission.test.ts test/taskControl.test.ts test/fastMode.test.ts test/panelCore.test.ts test/transcript.test.ts test/deliveryGuard.test.ts test/panelWidget.test.ts test/staleCtx.test.ts test/comparison.test.ts test/conversation.test.ts",
     "smoke": "tsx test/smoke.ts",
     "prepack": "npm run build",
     "postversion": "git push --follow-tags"

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -178,36 +178,78 @@ function sessionFileMatches(file: string, sessionName: string): boolean {
   }
 }
 
+function readJsonlSessionFiles(taskDir: string): string[] {
+  try {
+    return readdirSync(taskDir)
+      .filter((entry) => entry.endsWith(".jsonl"))
+      .map((entry) => join(taskDir, entry));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (
+      code === "ENOENT" ||
+      code === "ENOTDIR" ||
+      code === "EACCES" ||
+      code === "EPERM"
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}
+
 export function findJsonlSessionByName(
   piDir: string,
   idOrSessionName: string,
   agentType?: string,
 ): TaskSessionHistoryEntry | null {
-  const sessionsRoot = join(getArtifactDir(piDir), "sessions");
-  if (!existsSync(sessionsRoot)) return null;
-  const history = readTaskSessionHistory(piDir);
+  const history = readTaskSessionHistory(piDir).filter((entry) => {
+    if (entry.id !== idOrSessionName && entry.sessionName !== idOrSessionName) return false;
+    return !agentType || entry.agentType === agentType;
+  });
 
-  for (const dirent of readdirSync(sessionsRoot, { withFileTypes: true })) {
-    if (!dirent.isDirectory()) continue;
-    const taskId = dirent.name;
-    const taskDir = join(sessionsRoot, taskId);
-    const historyEntry = history.find((entry) => entry.id === taskId);
-    if (!historyEntry) continue;
-    const sessionName = historyEntry.sessionName;
-    if (taskId !== idOrSessionName && sessionName !== idOrSessionName) continue;
-    if (agentType && historyEntry.agentType !== agentType) continue;
+  for (const historyEntry of history) {
+    const sessionRoots = [
+      join(historyEntry.dir, "sessions"),
+      join(getArtifactDir(piDir), "tasks", "sessions"),
+      join(getArtifactDir(piDir), "sessions"),
+    ];
 
-    const sessionRef = readdirSync(taskDir)
-      .filter((entry) => entry.endsWith(".jsonl"))
-      .map((entry) => join(taskDir, entry))
-      .find((file) => sessionFileMatches(file, sessionName));
-    if (!sessionRef) continue;
+    for (const sessionsRoot of new Set(sessionRoots)) {
+      const taskDir = join(sessionsRoot, historyEntry.id);
+      if (!existsSync(taskDir)) continue;
 
-    return {
-      ...historyEntry,
-      sessionRef,
-      dir: taskDir,
-    };
+      const sessionRef = readJsonlSessionFiles(taskDir)
+        .find((file) => sessionFileMatches(file, historyEntry.sessionName));
+      if (!sessionRef) continue;
+
+      return { ...historyEntry, sessionRef };
+    }
   }
   return null;
+}
+
+export function ensureTaskSessionRef(
+  piDir: string,
+  entry: TaskSessionHistoryEntry,
+): TaskSessionHistoryEntry;
+export function ensureTaskSessionRef(
+  piDir: string,
+  entry: RegistryEntry,
+): RegistryEntry;
+export function ensureTaskSessionRef(
+  piDir: string,
+  entry: RegistryEntry,
+): RegistryEntry {
+  if (entry.sessionRef && existsSync(entry.sessionRef)) return entry;
+
+  const discovered = findJsonlSessionByName(piDir, entry.sessionName, entry.agentType);
+  if (!discovered?.sessionRef) return { ...entry, sessionRef: undefined };
+
+  const current = findTaskSessionHistory(piDir, entry.id);
+  if (current) {
+    const resolved = { ...current, sessionRef: discovered.sessionRef };
+    upsertTaskSessionHistory(piDir, resolved);
+    if ("status" in entry && "background" in entry) return resolved;
+  }
+  return { ...entry, sessionRef: discovered.sessionRef };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { registerTaskFastModeBridge } from "./fast-mode.js";
 export { createTaskFastModeStream, registerTaskFastModeBridge } from "./fast-mode.js";
 export type { TaskToolParameters } from "./tool/schema.js";
 import {
+  ensureTaskSessionRef,
   findJsonlSessionByName,
   normalizeConversationId,
   findTaskSessionHistory,
@@ -798,24 +799,9 @@ export default function (pi: ExtensionAPI) {
           findTaskSessionHistory(piDir, taskParams.task_id) ??
           findJsonlSessionByName(piDir, taskParams.task_id, agent.name);
 
-        // Older history entries were written before we stored the
-        // actual JSONL path needed by `pi --session`. Repair them by
-        // resolving the display session name to a session file.
-        if (entry && !entry.sessionRef) {
-          const discovered = findJsonlSessionByName(
-            piDir,
-            entry.sessionName,
-            entry.agentType,
-          );
-          if (discovered?.sessionRef) {
-            entry = { ...entry, sessionRef: discovered.sessionRef };
-            upsertTaskSessionHistory(piDir, {
-              ...entry,
-              status: "done",
-              background: false,
-            });
-          }
-        }
+        // Older history entries can have no JSONL path, or a stale one.
+        // Repair it before passing the path to `pi --session`.
+        if (entry) entry = ensureTaskSessionRef(piDir, entry);
         if (!entry) {
           taskParams = { ...taskParams, task_id: undefined };
           id = `${Date.now().toString(36)}-${randomUUID().slice(0, 4)}`;

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  ensureTaskSessionRef,
+  findJsonlSessionByName,
+  readTaskSessionHistory,
+  upsertTaskSessionHistory,
+} from "../src/conversation.js";
+
+function writeSession(taskDir: string, sessionName: string): string {
+  mkdirSync(taskDir, { recursive: true });
+  const sessionRef = join(taskDir, "session.jsonl");
+  writeFileSync(
+    sessionRef,
+    `${JSON.stringify({ type: "session_info", name: sessionName })}\n`,
+    "utf-8",
+  );
+  return sessionRef;
+}
+
+test("finds sessions in the current task artifact root", () => {
+  const piDir = mkdtempSync(join(tmpdir(), "pi-task-conversation-"));
+  const artifactsDir = join(piDir, "artifacts", "tasks");
+  const taskId = "task-123";
+  const sessionName = `task-${taskId}`;
+  const sessionRef = writeSession(join(artifactsDir, "sessions", taskId), sessionName);
+
+  upsertTaskSessionHistory(piDir, {
+    id: taskId,
+    agentType: "general",
+    description: "resume session",
+    sessionName,
+    startedAt: Date.now(),
+    piDir,
+    dir: artifactsDir,
+    status: "done",
+    background: true,
+  });
+
+  assert.equal(findJsonlSessionByName(piDir, taskId, "general")?.sessionRef, sessionRef);
+  assert.equal(findJsonlSessionByName(piDir, sessionName, "other"), null);
+});
+
+test("skips unavailable candidate directories while finding a session", () => {
+  const piDir = mkdtempSync(join(tmpdir(), "pi-task-conversation-unavailable-"));
+  const artifactsDir = join(piDir, "artifacts", "tasks");
+  const taskId = "task-unavailable";
+  const sessionName = `task-${taskId}`;
+  mkdirSync(join(artifactsDir, "sessions"), { recursive: true });
+  writeFileSync(
+    join(artifactsDir, "sessions", taskId),
+    "not-a-directory",
+    "utf-8",
+  );
+  const sessionRef = writeSession(
+    join(piDir, "artifacts", "sessions", taskId),
+    sessionName,
+  );
+
+  upsertTaskSessionHistory(piDir, {
+    id: taskId,
+    agentType: "general",
+    description: "skip unavailable root",
+    sessionName,
+    startedAt: Date.now(),
+    piDir,
+    dir: artifactsDir,
+    status: "done",
+    background: true,
+  });
+
+  assert.equal(findJsonlSessionByName(piDir, taskId, "general")?.sessionRef, sessionRef);
+});
+
+test("repairs a stale sessionRef without overwriting newer history metadata", () => {
+  const piDir = mkdtempSync(join(tmpdir(), "pi-task-conversation-repair-"));
+  const artifactsDir = join(piDir, "artifacts", "tasks");
+  const taskId = "task-repair";
+  const sessionName = `task-${taskId}`;
+  const sessionRef = writeSession(join(artifactsDir, "sessions", taskId), sessionName);
+  const entry = {
+    id: taskId,
+    agentType: "general",
+    description: "repair session",
+    sessionName,
+    sessionRef: join(piDir, "missing.jsonl"),
+    startedAt: Date.now(),
+    piDir,
+    dir: artifactsDir,
+    status: "done" as const,
+    background: true,
+  };
+  upsertTaskSessionHistory(piDir, entry);
+  upsertTaskSessionHistory(piDir, {
+    ...entry,
+    status: "running",
+    background: false,
+    cleanupPending: true,
+    comparisonGroupId: "comparison-1",
+    comparisonDescription: "newer comparison metadata",
+    comparisonDelivered: true,
+  });
+
+  const repaired = ensureTaskSessionRef(piDir, entry);
+  assert.equal(repaired.sessionRef, sessionRef);
+  assert.equal(repaired.status, "running");
+  assert.equal(repaired.background, false);
+  assert.equal(repaired.cleanupPending, true);
+  assert.equal(repaired.comparisonGroupId, "comparison-1");
+  assert.equal(repaired.comparisonDescription, "newer comparison metadata");
+  assert.equal(repaired.comparisonDelivered, true);
+  assert.deepEqual(readTaskSessionHistory(piDir)[0], repaired);
+});


### PR DESCRIPTION
## Summary

- resolve task sessions from the artifact root stored in task history
- retain compatibility with current and legacy session directories
- repair stale session references without overwriting newer history metadata
- handle missing or unreadable candidate directories

## Tests

- `npm test` (177 tests passed)
- `git diff --check upstream/main...HEAD`
- `npm run typecheck` remains blocked by the existing `@types/dompurify` ambient type error on an unchanged v0.6.0 checkout

Fixes #21
