### PR TITLE
feat: add per-call thinking-level control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   fast. The flag now reaches children through `resolveTaskFastMode` and installs
   the same provider bridge for the parent, so one flag covers both. An agent's
   frontmatter still overrides it.
-- The package ships a second extension entry point, `dist/fast.js`, for the
-  parent-side bridge. It registers no flag or command and writes no
-  configuration, and installs nothing unless `--fast` is set. Pi-task and
-  another extension that owns `--fast`, such as pi-codex-fast, cannot be loaded
-  together.
+- The main extension entry installs the parent-side Fast Mode bridge after
+  startup and handles isolated terminal children from the same flag owner.
+  Pi-task and another extension that owns `--fast`, such as pi-codex-fast,
+  cannot be loaded together.
 
 ## [0.7.2] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the same provider bridge for the parent, so one flag covers both. An agent's
   frontmatter still overrides it.
 - The package ships a second extension entry point, `dist/fast.js`, for the
-  parent-side bridge. It registers no command and writes no configuration, and
-  installs nothing unless `--fast` is set.
+  parent-side bridge. It registers no flag or command and writes no
+  configuration, and installs nothing unless `--fast` is set. Pi-task and
+  another extension that owns `--fast`, such as pi-codex-fast, cannot be loaded
+  together.
 
 ## [0.7.2] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the task request or agent frontmatter, and the parent's own calls were never
   fast. The flag now reaches children through `resolveTaskFastMode` and installs
   the same provider bridge for the parent, so one flag covers both. An agent's
-  frontmatter still overrides it.
+  frontmatter still overrides it. The built-in fallback also covers
+  `openai-codex/gpt-5.6-luna`.
 - The main extension entry installs the parent-side Fast Mode bridge after
   startup and handles isolated terminal children from the same flag owner.
   Pi-task and another extension that owns `--fast`, such as pi-codex-fast,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   field is rejected with the property named. Runtime validation remains the
   second layer for what the schema cannot express: a stale `operation`, blank
   strings, and the reviewer cross-field requirement.
+- Task calls accept an optional `thinking` level (`off`, `minimal`, `low`,
+  `medium`, `high`, `xhigh`, or `max`). Agent frontmatter remains authoritative;
+  the call-level value applies when the agent leaves it unset, across Pi, SDK,
+  Claude Code, and comparison launches.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Parent reasoning that lives outside the referenced files goes in `parent_context
 
 An optional `thinking` task parameter accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Agent frontmatter wins; the call-level value applies only when the selected agent omits `thinking`. The resolved value is forwarded through Pi, SDK, Claude Code, and comparison launches.
 
-Fast Mode is optional and driven by one flag: `pi --fast` applies the priority service tier to the session's own model calls and to every child it delegates to. An agent's `fast: true` or `fast: false` frontmatter overrides it for that agent; behavior defaults to `false`. The package ships two extension entry points, `dist/index.js` for delegation and `dist/fast.js` for the parent-side bridge, and the second installs nothing unless the flag is set. Load only one extension that owns `--fast`; Pi reports a conflict when pi-task and another fast-mode extension such as pi-codex-fast are enabled together.
+Fast Mode is optional and driven by one flag: `pi --fast` applies the priority service tier to the session's own model calls and to every child it delegates to. An agent's `fast: true` or `fast: false` frontmatter overrides it for that agent; behavior defaults to `false`. The main `dist/index.js` entry installs the parent-side bridge after startup and also handles isolated terminal children. Load only one extension that owns `--fast`; Pi reports a conflict when pi-task and another fast-mode extension such as pi-codex-fast are enabled together.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Parent reasoning that lives outside the referenced files goes in `parent_context
 
 An optional `thinking` task parameter accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Agent frontmatter wins; the call-level value applies only when the selected agent omits `thinking`. The resolved value is forwarded through Pi, SDK, Claude Code, and comparison launches.
 
-Fast Mode is optional and driven by one flag: `pi --fast` applies the priority service tier to the session's own model calls and to every child it delegates to. An agent's `fast: true` or `fast: false` frontmatter overrides it for that agent; behavior defaults to `false`. The package ships two extension entry points, `dist/index.js` for delegation and `dist/fast.js` for the parent-side bridge, and the second installs nothing unless the flag is set.
+Fast Mode is optional and driven by one flag: `pi --fast` applies the priority service tier to the session's own model calls and to every child it delegates to. An agent's `fast: true` or `fast: false` frontmatter overrides it for that agent; behavior defaults to `false`. The package ships two extension entry points, `dist/index.js` for delegation and `dist/fast.js` for the parent-side bridge, and the second installs nothing unless the flag is set. Load only one extension that owns `--fast`; Pi reports a conflict when pi-task and another fast-mode extension such as pi-codex-fast are enabled together.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For the full high-quality 89s @ 56 fps version, [download the MP4](https://githu
 - Tmux backend for observable subagent panes.
 - HerdR and tmux terminal backends, with SDK fallback when neither is available.
 - Agent frontmatter support: `model`, `thinking`, `fast`, `skills`, `tools`, `disallowed_tools`.
+- Per-call thinking control: an optional task `thinking` value uses Pi's canonical levels when the agent leaves `thinking` unset; frontmatter remains authoritative when present.
 - Task-local OpenAI/OpenAI-Codex Fast Mode: apply priority service tier to configured models without changing model, thinking level, or shared configuration.
 - Built-in starter agents: `scout`, `explore`, `general`, `reviewer`.
 - Project/user agent overrides via `.pi/agents/*.md` or `~/.pi/agent/agents/*.md`.
@@ -40,7 +41,7 @@ Restart Pi after installing or changing extension config.
 
 ## Usage
 
-The handoff contract lives in the `task` schema. Pi validates tool arguments against `parameters` before the tool runs and reports the missing property by name, so `agent_type`, `description`, and `prompt` are enforced rather than merely stated. Runtime validation is the second layer for what the schema cannot express: a stale `operation`, blank strings, and the reviewer cross-field requirement. `prompt` carries:
+The handoff contract lives in the `task` schema. Pi validates tool arguments against `parameters` before the tool runs and reports the missing property by name, so `agent_type`, `description`, and `prompt` are enforced rather than merely stated. Runtime validation is the second layer for what the schema cannot express: a stale `operation`, blank strings, thinking values, and the reviewer cross-field requirement. `prompt` carries:
 
 - goal: the exact outcome wanted
 - scope and references: what to inspect, why each reference matters, and the base/diff to review; paths are evidence, not context handoff
@@ -50,6 +51,8 @@ The handoff contract lives in the `task` schema. Pi validates tool arguments aga
 - verification recipe: checks to run or evidence to gather
 
 Parent reasoning that lives outside the referenced files goes in `parent_context` and `proposed_changes` rather than in `prompt`.
+
+An optional `thinking` task parameter accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Agent frontmatter wins; the call-level value applies only when the selected agent omits `thinking`. The resolved value is forwarded through Pi, SDK, Claude Code, and comparison launches.
 
 Fast Mode is optional and driven by one flag: `pi --fast` applies the priority service tier to the session's own model calls and to every child it delegates to. An agent's `fast: true` or `fast: false` frontmatter overrides it for that agent; behavior defaults to `false`. The package ships two extension entry points, `dist/index.js` for delegation and `dist/fast.js` for the parent-side bridge, and the second installs nothing unless the flag is set.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Fast Mode is optional and driven by one flag: `pi --fast` applies the priority s
 }
 ```
 
-When effective Fast Mode is enabled, a configured OpenAI or OpenAI-Codex child uses `serviceTier: "priority"` when its model is listed in `pi-codex-fast.json` under the Pi agent directory. The config's `enabled` value is not consulted, and pi-task never writes the file. If that file is missing or invalid, the built-in fallback list applies: `openai/gpt-5.4`, `openai/gpt-5.5`, `openai-codex/gpt-5.4`, `openai-codex/gpt-5.5` (same behavior as pi-codex-fast). Unsupported or unlisted models use their normal streamer. Terminal children use an isolated provider bridge; SDK children inject the same bridge while keeping normal extension discovery disabled.
+When effective Fast Mode is enabled, a configured OpenAI or OpenAI-Codex child uses `serviceTier: "priority"` when its model is listed in `pi-codex-fast.json` under the Pi agent directory. The config's `enabled` value is not consulted, and pi-task never writes the file. If that file is missing or invalid, the built-in fallback list applies: `openai/gpt-5.4`, `openai/gpt-5.5`, `openai-codex/gpt-5.4`, `openai-codex/gpt-5.5`, `openai-codex/gpt-5.6-luna`. Unsupported or unlisted models use their normal streamer. Terminal children use an isolated provider bridge; SDK children inject the same bridge while keeping normal extension discovery disabled.
 
 A reviewer request with missing parent_context or proposed_changes is rejected. If there are no design changes, pass an explicit item such as “No proposed design changes; assess the implementation against the stated goal.”
 

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
   },
   "pi": {
     "extensions": [
-      "./dist/index.js",
-      "./dist/fast.js"
+      "./dist/index.js"
     ],
     "video": "https://github.com/heyhuynhgiabuu/pi-task/releases/download/v0.2.0/demo-background-task.mp4",
     "image": "https://raw.githubusercontent.com/heyhuynhgiabuu/pi-task/main/media/demo.png"

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -35,6 +35,7 @@ const DEFAULT_FAST_MODELS = [
   "openai/gpt-5.5",
   "openai-codex/gpt-5.4",
   "openai-codex/gpt-5.5",
+  "openai-codex/gpt-5.6-luna",
 ] as const;
 
 interface TaskFastModeConfig {

--- a/src/fast.ts
+++ b/src/fast.ts
@@ -1,28 +1,25 @@
 /**
- * Parent-side fast mode.
+ * Parent-side fast mode setup.
  *
  * `--fast` on the parent already reaches its children — that is what
  * `resolveTaskFastMode` decides — but the parent's own model calls were
- * untouched, because the provider bridge in `fast-mode.ts` is installed only in
- * a child. That is what "task-local" means there. This entry point installs the
- * same bridge for the session that passes the flag, so one flag covers the
- * parent and everything it delegates to.
- *
- * `index.ts` owns the shared `--fast` flag; this entry only consumes it. It
- * registers no flag or command, keeps no state, and writes no configuration.
+ * untouched, because the provider bridge in `fast-mode.ts` was installed only
+ * in a child. This helper installs the same bridge for the parent session.
+ * The caller must be the extension that owns the `fast` flag because Pi scopes
+ * `getFlag()` to that extension.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { registerTaskFastModeBridge } from "./fast-mode.js";
 
-export default function fastExtension(pi: ExtensionAPI): void {
-  // Read at session_start rather than at load time: the shared flag value is
-  // settled once the session is running. The main entry point is the sole
-  // owner of `--fast`, so loading both package entries cannot create a flag
-  // conflict.
+export function registerParentFastMode(pi: ExtensionAPI): void {
+  let fastModeBridgeInstalled = false;
+  // Read at session_start rather than at load time: the flag value is settled
+  // once the session is running.
   pi.on("session_start", () => {
-    if (pi.getFlag("fast") !== true) return;
+    if (fastModeBridgeInstalled || pi.getFlag("fast") !== true) return;
+    fastModeBridgeInstalled = true;
     registerTaskFastModeBridge(pi);
   });
 }

--- a/src/fast.ts
+++ b/src/fast.ts
@@ -8,8 +8,8 @@
  * same bridge for the session that passes the flag, so one flag covers the
  * parent and everything it delegates to.
  *
- * It registers no command, keeps no state, and writes no configuration: the
- * flag is the whole interface.
+ * `index.ts` owns the shared `--fast` flag; this entry only consumes it. It
+ * registers no flag or command, keeps no state, and writes no configuration.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -17,16 +17,10 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerTaskFastModeBridge } from "./fast-mode.js";
 
 export default function fastExtension(pi: ExtensionAPI): void {
-  pi.registerFlag("fast", {
-    description: "Use the priority service tier for this session and its delegated children",
-    type: "boolean",
-    default: false,
-  });
-
-  // Read at session_start rather than at load time: the flag value is only
-  // settled once the session is running, and installing after every extension
-  // has loaded is what lets this bridge take precedence over a globally
-  // installed pi-codex-fast without touching that extension's configuration.
+  // Read at session_start rather than at load time: the shared flag value is
+  // settled once the session is running. The main entry point is the sole
+  // owner of `--fast`, so loading both package entries cannot create a flag
+  // conflict.
   pi.on("session_start", () => {
     if (pi.getFlag("fast") !== true) return;
     registerTaskFastModeBridge(pi);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentToolAllowlist,
 } from "./agent-tools.js";
 import { parseMergedDisallowedTools } from "./policy.js";
+import type { PiThinkingLevel } from "./thinking.js";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
   buildPiArgv,
@@ -854,6 +855,15 @@ export function resolveTaskFastMode(
   sessionFast: boolean,
 ): boolean {
   return agentFast ?? sessionFast;
+}
+
+/** Apply a call-level thinking default without overriding agent frontmatter. */
+export function resolveTaskThinking(
+  agent: AgentConfig,
+  requestedThinking?: PiThinkingLevel,
+): AgentConfig {
+  if (agent.thinking?.trim() || requestedThinking === undefined) return agent;
+  return { ...agent, thinking: requestedThinking };
 }
 
 /** Turn limits (issue #19) must be positive integers; anything else is unlimited. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import {
       discoverAgents,
   resolveTaskAgentPreflight,
   resolveTaskFastMode,
+  resolveTaskThinking,
   isTaskCompareAllowed,
   resolveCompareModels,
 } from "./helpers.js";
@@ -439,7 +440,7 @@ export default function (pi: ExtensionAPI) {
           isError: true,
         };
       }
-      const agent = preflight.agent;
+      const agent = resolveTaskThinking(preflight.agent, taskParams.thinking);
       if (taskParams.cwd !== undefined) {
         const requestedTaskCwd = resolveTaskCwd(ctx.cwd, taskParams.cwd);
         if (requestedTaskCwd.kind === "invalid") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {
   MAX_POLL_ERRORS,
   TASK_TIMEOUT_MS,
 } from "./constants.js";
-import { registerTaskFastModeBridge } from "./fast-mode.js";
+import { registerParentFastMode } from "./fast.js";
 export { createTaskFastModeStream, registerTaskFastModeBridge } from "./fast-mode.js";
 export type { TaskToolParameters } from "./tool/schema.js";
 import {
@@ -126,27 +126,20 @@ const BUNDLED_AGENT_DIR = join(
 // ─── Extension Entry Point ──────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
-  // Registered in both branches: the parent reads it to decide whether its
-  // children run fast, a child launched with `--fast` reads it to install its
-  // isolated provider bridge, and `fast.ts` reads it to install the same bridge
-  // for the parent's own calls. A manual `pi -e pi-task --fast` in a normal
-  // session is therefore accepted instead of dying as "Unknown option".
+  // The parent reads this to decide whether its children run fast, and a
+  // terminal child launched with `--fast` reads it to install its isolated
+  // provider bridge. Keep one owner for the flag: Pi's getFlag() is scoped to
+  // the extension that registered it.
   pi.registerFlag("fast", {
     description: "Use the priority service tier for this session and its delegated children",
     type: "boolean",
     default: false,
   });
+  registerParentFastMode(pi);
+
   // Recursive children never register task. An explicitly fast terminal child
   // loads this same extension path only to install its isolated provider bridge.
-  if (process.env.PI_TASK_TOOL_DISABLED === "1") {
-    let fastModeBridgeInstalled = false;
-    pi.on("session_start", () => {
-      if (fastModeBridgeInstalled || pi.getFlag("fast") !== true) return;
-      fastModeBridgeInstalled = true;
-      registerTaskFastModeBridge(pi);
-    });
-    return;
-  }
+  if (process.env.PI_TASK_TOOL_DISABLED === "1") return;
 
   const taskToolName = process.env.PI_TASK_TOOL_NAME?.trim() || "task";
   if (!/^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(taskToolName)) {

--- a/src/task-control.ts
+++ b/src/task-control.ts
@@ -1,5 +1,10 @@
 import { getExitSentinelPath } from "./subagent/exitSentinel.js";
 import { claudeSessionFilePath } from "./subagent/claudeSession.js";
+import {
+  normalizePiThinkingLevel,
+  PI_THINKING_LEVELS,
+  type PiThinkingLevel,
+} from "./thinking.js";
 import type {
   BackgroundTask,
   ExecutionBackend,
@@ -26,6 +31,7 @@ export interface TaskStartRequest {
   agent_type: string;
   prompt: string;
   description: string;
+  thinking?: PiThinkingLevel;
   parent_context?: string;
   proposed_changes?: string[];
   workspace_group?: string;
@@ -226,6 +232,17 @@ function validateTaskStartRequest(value: unknown): TaskStartValidation {
   if (candidate.compare !== undefined && typeof candidate.compare !== "boolean") {
     problems.push("compare must be a boolean");
   }
+  let thinking: PiThinkingLevel | undefined;
+  if (candidate.thinking !== undefined) {
+    if (typeof candidate.thinking !== "string") {
+      problems.push("thinking must be a string");
+    } else {
+      thinking = normalizePiThinkingLevel(candidate.thinking);
+      if (thinking === undefined) {
+        problems.push(`thinking must be one of: ${PI_THINKING_LEVELS.join(", ")}`);
+      }
+    }
+  }
   if (problems.length > 0) return { problems };
 
   const parsedPromptHandoff = parsePromptHandoff(candidate.prompt as string);
@@ -287,6 +304,7 @@ function validateTaskStartRequest(value: unknown): TaskStartValidation {
       agent_type: candidate.agent_type as string,
       prompt: candidate.prompt as string,
       description: candidate.description as string,
+      ...(thinking !== undefined ? { thinking } : {}),
       ...(parentContext !== undefined ? { parent_context: parentContext } : {}),
       ...(proposedChanges !== undefined ? { proposed_changes: proposedChanges } : {}),
       ...(typeof candidate.workspace_group === "string" ? { workspace_group: candidate.workspace_group } : {}),

--- a/src/thinking.ts
+++ b/src/thinking.ts
@@ -1,0 +1,23 @@
+export const PI_THINKING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+export type PiThinkingLevel = (typeof PI_THINKING_LEVELS)[number];
+
+const PI_THINKING_LEVEL_SET = new Set<string>(PI_THINKING_LEVELS);
+
+export function normalizePiThinkingLevel(
+  value: unknown,
+): PiThinkingLevel | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return PI_THINKING_LEVEL_SET.has(normalized)
+    ? (normalized as PiThinkingLevel)
+    : undefined;
+}

--- a/src/tool/schema.ts
+++ b/src/tool/schema.ts
@@ -1,4 +1,5 @@
 import { Type, type Static } from "typebox";
+import { PI_THINKING_LEVELS } from "../thinking.js";
 
 /**
  * The model-facing parameter surface, paid on every turn.
@@ -7,7 +8,7 @@ import { Type, type Static } from "typebox";
  * validates tool arguments against `parameters` before `execute` and reports
  * the missing property by name, so `required` is enforced rather than stated.
  * `parseTaskStartRequest` covers what the schema cannot express — a stale
- * `operation`, blank strings, the reviewer cross-field requirement.
+ * `operation`, blank strings, thinking values, the reviewer cross-field requirement.
  *
  * Deliberately absent: `operation` (start and resume are told apart by
  * `task_id`; status and cancel belong to `/task`) and `fast` (a session or
@@ -31,6 +32,9 @@ export function taskParametersSchema() {
       description:
         "The handoff: goal, scope, non-goals, write policy, acceptance criteria, verification recipe. Parent reasoning learned outside the referenced files goes in parent_context and proposed_changes.",
     }),
+    thinking: Type.Optional(Type.String({
+      description: `Thinking; frontmatter wins: ${PI_THINKING_LEVELS.join("|")}`,
+    })),
     task_id: Type.Optional(
       Type.String({
         description: "Resume this task instead of starting a fresh one",

--- a/test/fastEntry.test.ts
+++ b/test/fastEntry.test.ts
@@ -3,9 +3,8 @@
  *
  * It exists so one `--fast` covers the parent's own model calls as well as
  * everything it delegates to. The bridge itself is exercised elsewhere; what
- * matters here is that nothing is installed unless the flag is set, because
- * installing it unconditionally would override a globally installed
- * pi-codex-fast for every session.
+ * matters here is that nothing is installed unless the shared flag is set,
+ * because installing it unconditionally would change every session.
  */
 
 import { strict as assert } from "node:assert";
@@ -14,18 +13,16 @@ import test from "node:test";
 import fastExtension from "../src/fast.js";
 
 interface Harness {
-	flags: Map<string, unknown>;
 	handlers: Map<string, () => void>;
 	providers: string[];
 }
 
 function harness(flagValue: boolean | string | undefined): Harness {
-	const flags = new Map<string, unknown>();
 	const handlers = new Map<string, () => void>();
 	const providers: string[] = [];
 	const pi = {
-		registerFlag(name: string, options: { default?: unknown }) {
-			flags.set(name, options.default);
+		registerFlag() {
+			throw new Error("the shared fast flag must be registered by index.ts");
 		},
 		getFlag(name: string) {
 			return name === "fast" ? flagValue : undefined;
@@ -38,13 +35,12 @@ function harness(flagValue: boolean | string | undefined): Harness {
 		},
 	};
 	fastExtension(pi as never);
-	return { flags, handlers, providers };
+	return { handlers, providers };
 }
 
-test("the fast entry point registers the flag and defers to session start", () => {
-	const { flags, handlers, providers } = harness(undefined);
+test("the fast entry point reuses the shared flag and defers to session start", () => {
+	const { handlers, providers } = harness(undefined);
 
-	assert.equal(flags.get("fast"), false, "the flag defaults to false");
 	assert.ok(handlers.has("session_start"), "the bridge is decided at session start");
 	assert.deepEqual(providers, [], "nothing is registered at load time");
 });

--- a/test/fastEntry.test.ts
+++ b/test/fastEntry.test.ts
@@ -1,5 +1,5 @@
 /**
- * The parent-side fast entry point.
+ * The parent-side fast mode setup.
  *
  * It exists so one `--fast` covers the parent's own model calls as well as
  * everything it delegates to. The bridge itself is exercised elsewhere; what
@@ -10,7 +10,7 @@
 import { strict as assert } from "node:assert";
 import test from "node:test";
 
-import fastExtension from "../src/fast.js";
+import { registerParentFastMode } from "../src/fast.js";
 
 interface Harness {
 	handlers: Map<string, () => void>;
@@ -34,11 +34,11 @@ function harness(flagValue: boolean | string | undefined): Harness {
 			providers.push(name);
 		},
 	};
-	fastExtension(pi as never);
+	registerParentFastMode(pi as never);
 	return { handlers, providers };
 }
 
-test("the fast entry point reuses the shared flag and defers to session start", () => {
+test("parent fast mode reuses the shared flag and defers to session start", () => {
 	const { handlers, providers } = harness(undefined);
 
 	assert.ok(handlers.has("session_start"), "the bridge is decided at session start");

--- a/test/fastMode.test.ts
+++ b/test/fastMode.test.ts
@@ -7,6 +7,7 @@ import { buildBaseOptions as buildNativeBaseOptions } from "@earendil-works/pi-a
 import taskExtension, * as taskModule from "../src/index.js";
 import {
   createAgentSessionFromServices,
+  createAgentSessionRuntime,
   createAgentSessionServices,
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
@@ -141,7 +142,7 @@ test("PI_TASK_TOOL_DISABLED child registers fast providers after real flag appli
       },
     });
 
-    // The old factory-time getFlag() read leaves the bridge absent here and after startup.
+    // Registration is deferred until the real session_start event.
     assert.deepEqual(services.modelRuntime.getRegisteredProviderIds(), []);
 
     const { session } = await createAgentSessionFromServices({
@@ -167,6 +168,57 @@ test("PI_TASK_TOOL_DISABLED child registers fast providers after real flag appli
       session.dispose();
     }
   } finally {
+    if (previousDisabled === undefined) delete process.env.PI_TASK_TOOL_DISABLED;
+    else process.env.PI_TASK_TOOL_DISABLED = previousDisabled;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("parent task extension installs fast providers after startup", async () => {
+  const previousDisabled = process.env.PI_TASK_TOOL_DISABLED;
+  delete process.env.PI_TASK_TOOL_DISABLED;
+  const cwd = mkdtempSync(join(tmpdir(), "pi-task-parent-fast-cwd-"));
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-task-parent-fast-agent-"));
+  const originalCwd = process.cwd();
+
+  try {
+    process.chdir(cwd);
+    const sessionManager = SessionManager.inMemory(cwd);
+    const runtime = await createAgentSessionRuntime(
+      async ({ cwd: runtimeCwd, agentDir: runtimeAgentDir, sessionManager: runtimeSessionManager, sessionStartEvent }) => {
+        const services = await createAgentSessionServices({
+          cwd: runtimeCwd,
+          agentDir: runtimeAgentDir,
+          extensionFlagValues: new Map([["fast", true]]),
+          resourceLoaderOptions: {
+            noExtensions: true,
+            extensionFactories: [{ name: "pi-task-parent", factory: taskExtension }],
+          },
+        });
+        const result = await createAgentSessionFromServices({
+          services,
+          sessionManager: runtimeSessionManager,
+          sessionStartEvent,
+          noTools: "all",
+        });
+        return { ...result, services, diagnostics: services.diagnostics };
+      },
+      { cwd, agentDir, sessionManager },
+    );
+
+    assert.deepEqual(runtime.services.modelRuntime.getRegisteredProviderIds(), []);
+    try {
+      await runtime.session.bindExtensions({});
+      assert.deepEqual(
+        new Set(runtime.services.modelRuntime.getRegisteredProviderIds()),
+        new Set(["openai", "openai-codex"]),
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  } finally {
+    process.chdir(originalCwd);
     if (previousDisabled === undefined) delete process.env.PI_TASK_TOOL_DISABLED;
     else process.env.PI_TASK_TOOL_DISABLED = previousDisabled;
     rmSync(cwd, { recursive: true, force: true });

--- a/test/fastMode.test.ts
+++ b/test/fastMode.test.ts
@@ -37,11 +37,13 @@ const baseArgvOptions: BuildPiArgvOptions = {
   promptContent: "perform the task",
 };
 
-function createFastStreamHarness(models: string[]) {
+function createFastStreamHarness(models?: string[]) {
   const agentDir = mkdtempSync(join(tmpdir(), "pi-task-fast-options-"));
-  const configDir = join(agentDir, "extensions");
-  mkdirSync(configDir, { recursive: true });
-  writeFileSync(join(configDir, "pi-codex-fast.json"), JSON.stringify({ models }));
+  if (models !== undefined) {
+    const configDir = join(agentDir, "extensions");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "pi-codex-fast.json"), JSON.stringify({ models }));
+  }
 
   const calls: Array<{ model: unknown; context: unknown; options: Record<string, unknown> }> = [];
   const capture = (model: unknown, context: unknown, options: unknown) => {
@@ -247,6 +249,25 @@ test("SDK loader keeps extensions disabled and injects fast bridge only when req
   assert.equal(fast.extensionFactories?.[0]?.name, "pi-task-fast-mode");
   assert.equal(normal.noExtensions, true);
   assert.deepEqual(normal.extensionFactories ?? [], []);
+});
+
+test("the fallback fast model list includes openai-codex gpt-5.6-luna", () => {
+  const { agentDir, calls, stream } = createFastStreamHarness();
+  const model = {
+    provider: "openai-codex",
+    id: "gpt-5.6-luna",
+    api: "openai-codex-responses",
+    maxTokens: 20_000,
+    contextWindow: 400_000,
+    reasoning: true,
+  };
+
+  try {
+    stream(model as never, { messages: [] }, { reasoning: "high" });
+    assert.equal(calls[0]?.options.serviceTier, "priority");
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+  }
 });
 
 test("configured fast models preserve native options and add only priority", () => {

--- a/test/frontmatter.test.ts
+++ b/test/frontmatter.test.ts
@@ -3,7 +3,7 @@ import { strict as assert } from "node:assert";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { envTurnLimit, loadAgentsFromDir, parseBool, parseModelList, parseModelSpecs, resolveTaskFastMode, type AgentConfig } from "../src/helpers.js";
+import { envTurnLimit, loadAgentsFromDir, parseBool, parseModelList, parseModelSpecs, resolveTaskFastMode, resolveTaskThinking, type AgentConfig } from "../src/helpers.js";
 
 {
   const t = "parseBool";
@@ -84,6 +84,27 @@ No description.`,
   assert.equal(resolveTaskFastMode(undefined, false), false, t + ": no flag and no setting");
   assert.equal(resolveTaskFastMode(true, false), true, t + ": agent true wins");
   assert.equal(resolveTaskFastMode(false, true), false, t + ": agent false wins");
+}
+
+{
+  const t = "resolveTaskThinking uses the call value only when frontmatter is silent";
+  const base: AgentConfig = {
+    name: "dynamic",
+    description: "Dynamic agent",
+    body: "",
+    source: "bundled",
+    path: "",
+  };
+  const resolved = resolveTaskThinking(base, "high");
+  assert.equal(resolved.thinking, "high", t + ": call value applies");
+  assert.notEqual(resolved, base, t + ": dynamic agent is copied");
+  assert.equal(base.thinking, undefined, t + ": source agent is unchanged");
+  assert.equal(
+    resolveTaskThinking({ ...base, thinking: "max" }, "low").thinking,
+    "max",
+    t + ": frontmatter wins",
+  );
+  assert.equal(resolveTaskThinking(base), base, t + ": no request preserves identity");
 }
 
 {

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -96,6 +96,8 @@ test("the schema is the only home for the handoff contract", () => {
 	assert.match(schema.properties.parent_context?.description ?? "", /outside the referenced files/i, "parent_context says what belongs in it");
 	assert.match(schema.properties.parent_context?.description ?? "", /required for reviewer tasks/i, "parent_context names its reviewer requirement");
 	assert.match(schema.properties.proposed_changes?.description ?? "", /required non-empty for reviewer tasks/i, "proposed_changes names its reviewer requirement");
+	assert.match(schema.properties.thinking?.description ?? "", /frontmatter wins/i, "thinking states precedence");
+	assert.match(schema.properties.thinking?.description ?? "", /off\|minimal\|low\|medium\|high\|xhigh\|max/i, "thinking lists Pi's levels");
 	assert.match(schema.properties.cwd?.description ?? "", /absolute existing directory/i, "cwd states its validation");
 	assert.match(schema.properties.cwd?.description ?? "", /does not create.*worktree/i, "cwd states the worktree guarantee");
 });
@@ -104,6 +106,8 @@ test("optional fields accept their documented shapes and reject others", () => {
 	const base = { agent_type: "reviewer", description: "Review", prompt: "Review the diff." };
 
 	assert.equal(validate(base).accepted, true, "optional fields may be omitted");
+	assert.equal(validate({ ...base, thinking: "high" }).accepted, true, "thinking is an optional string");
+	assert.equal(validate({ ...base, thinking: 1 }).accepted, false, "thinking rejects non-strings");
 	assert.equal(
 		validate({ ...base, parent_context: "The parent read the diff.", proposed_changes: ["No design changes"] }).accepted,
 		true,

--- a/test/taskControl.test.ts
+++ b/test/taskControl.test.ts
@@ -17,6 +17,7 @@ import {
   taskStartRequestError,
   type TaskControlRecord,
 } from "../src/task-control.js";
+import { PI_THINKING_LEVELS } from "../src/thinking.js";
 
 // Delegated pi-task children disable recursive registration; this file registers the host extension.
 const inheritedTaskToolDisabled = process.env.PI_TASK_TOOL_DISABLED;
@@ -44,6 +45,40 @@ test("task start parsing supplies runtime validation for the flat provider schem
     description: "Inspect the repository",
     prompt: 42,
   }), undefined);
+});
+
+test("thinking accepts Pi's canonical levels and normalizes them", () => {
+  const base = {
+    agent_type: "explore",
+    description: "Inspect the repository",
+    prompt: "Map the repository.",
+  };
+
+  for (const level of PI_THINKING_LEVELS) {
+    assert.equal(
+      parseTaskStartRequest({ ...base, thinking: ` ${level.toUpperCase()} ` })?.thinking,
+      level,
+      `${level} is accepted and normalized`,
+    );
+  }
+  assert.equal(parseTaskStartRequest(base)?.thinking, undefined, "thinking remains optional");
+});
+
+test("thinking rejects unknown or non-string values", () => {
+  const base = {
+    agent_type: "explore",
+    description: "Inspect the repository",
+    prompt: "Map the repository.",
+  };
+
+  assert.equal(parseTaskStartRequest({ ...base, thinking: "turbo" }), undefined);
+  assert.equal(
+    taskStartRequestError({ ...base, thinking: "turbo" }),
+    "thinking must be one of: off, minimal, low, medium, high, xhigh, max",
+  );
+  assert.equal(parseTaskStartRequest({ ...base, thinking: 1 }), undefined);
+  assert.equal(taskStartRequestError({ ...base, thinking: 1 }), "thinking must be a string");
+  assert.match(taskStartRequestError({ ...base, thinking: "   " }) ?? "", /^thinking must be one of:/);
 });
 
 test("fast is rejected as a removed task parameter", () => {


### PR DESCRIPTION
## Summary

- Add an optional `thinking` task parameter using Pi's canonical levels.
- Keep agent frontmatter authoritative and route the resolved value through the existing Pi, SDK, Claude Code, and comparison launch seams.
- Validate and normalize call values at the task parser boundary.
- Make `index.ts` the sole pi-task owner of `--fast`; the parent and terminal child bridge now use the same extension entry, removing the internal startup conflict.

Fixes #25

## Compatibility notes

- Agents that declare `thinking` in frontmatter keep that value; the call-level field affects agents that leave it unset.
- Effective thinking is launch-time state in this PR; durable thinking metadata for resume/status remains a follow-up to the existing registry work.
- Pi cannot load pi-task together with another extension that registers `--fast` (for example `pi-codex-fast`). Choose one owner in Pi settings.

## Verification

- `npm test` — 274/274 passing
- `npm run typecheck`
- `npm run build`
- `git diff --check`
